### PR TITLE
Add initial support for heapless

### DIFF
--- a/minicbor-tests/Cargo.toml
+++ b/minicbor-tests/Cargo.toml
@@ -11,9 +11,11 @@ description = "minicbor test suite"
 alloc  = ["minicbor/alloc"]
 std    = ["alloc", "minicbor/std", "minicbor/derive"]
 derive = ["alloc", "minicbor/derive"]
+heapless = ["dep:heapless", "minicbor/heapless"]
 
 [dependencies]
 arbitrary = { version = "1.3.2", features = ["derive"] }
+heapless = { version = "0.8.0", default-features = false, optional = true }
 minicbor  = { path = "../minicbor", features = ["half"] }
 
 [dev-dependencies]

--- a/minicbor-tests/tests/encoding.rs
+++ b/minicbor-tests/tests/encoding.rs
@@ -259,3 +259,11 @@ fn regular_enum() {
     assert!(d.skip().unwrap_err().is_end_of_input())
 }
 
+#[cfg(feature = "heapless")]
+#[test]
+fn heapless() {
+    let original = heapless::String::<20>::try_from("BOR").unwrap();
+    let bytes = minicbor::to_vec(&original).unwrap();
+    assert_eq!(&b"cBOR"[..], &bytes[..]);
+    assert_eq!(original, minicbor::decode::<heapless::String::<20>>(&bytes).unwrap());
+}

--- a/minicbor/Cargo.toml
+++ b/minicbor/Cargo.toml
@@ -14,14 +14,16 @@ build         = "build.rs"
 features = ["std", "derive", "half"]
 
 [features]
-full   = ["std", "derive", "half"]
-alloc  = ["minicbor-derive?/alloc"]
-std    = ["alloc", "minicbor-derive?/std"]
-derive = ["minicbor-derive"]
+full     = ["std", "derive", "half"]
+alloc    = ["minicbor-derive?/alloc"]
+std      = ["alloc", "minicbor-derive?/std"]
+derive   = ["minicbor-derive"]
+heapless = ["dep:heapless"]
 
 [dependencies]
 minicbor-derive = { version = "0.15.0", path = "../minicbor-derive", optional = true }
 half            = { version = "2.4.0", default-features = false, optional = true }
+heapless        = { version = "0.8.0", default-features = false, optional = true }
 
 [dev-dependencies]
 minicbor = { path = ".", features = ["std", "half"] }

--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -748,3 +748,16 @@ impl<'b, C, T: Decode<'b, C>> Decode<'b, C> for core::ops::Bound<T> {
     }
 }
 
+#[cfg(feature = "heapless")]
+impl<'b, C, const N: usize> Decode<'b, C> for heapless::String<N> {
+    fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, Error> {
+        let s = d.str()?;
+        heapless::String::try_from(s).map_err(|()| {
+            #[cfg(feature = "alloc")]
+            let msg = &alloc::format!("string has more than {N} bytes");
+            #[cfg(not(feature = "alloc"))]
+            let msg = "string has too many bytes";
+            Error::message(msg)
+        })
+    }
+}

--- a/minicbor/src/encode.rs
+++ b/minicbor/src/encode.rs
@@ -1081,3 +1081,19 @@ where
         Ok(())
     }
 }
+
+#[cfg(feature = "heapless")]
+impl<C, const N: usize> Encode<C> for heapless::String<N> {
+    fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
+        let s: &str = &*self;
+        s.encode(e, ctx)
+    }
+}
+
+#[cfg(feature = "heapless")]
+impl<C, const N: usize> CborLen<C> for heapless::String<N> {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        let s: &str = &*self;
+        s.cbor_len(ctx)
+    }
+}


### PR DESCRIPTION
The common embedded string type `heapless::String` is not supported in minicbor; neither are other common heapless types. Its implementation largely follows that of the `alloc::…::String`, although it takes a slightly different choice for encoding by fully deferring to the deref'd `str`.

Without introducing extra wrappers, this can only be done either in `heapless` or here. While `heapless` does implement serialization for `serde`, following the pattern of "smaller crate provides implementations for larger crate" and "unstable crate provides implementations for unstable crate", this would best sit here. (`heapless` is also unstable, but rather slow in breaking things.)

This PR adds support for `heapless::String` only. It is designed for early review as a test balloon – if the way this is done is fine for you, I'd add at least `heapless::Vec` (following `alloc::…::Vec`), if you prefer already in this PR. There are more types that could be expressed (`heapless` itself provides `serde` implementations also for its `BinaryHeap`, `IndexSet`, `LinearMap` and `IndexMap`), but as I have no experience with them, I'd defer them to implementation as needed, unless you insist on full coverage.