### PR TITLE
Make Encoder::put() public

### DIFF
--- a/minicbor/src/encode/encoder.rs
+++ b/minicbor/src/encode/encoder.rs
@@ -282,7 +282,11 @@ impl<W: Write> Encoder<W> {
     }
 
     /// Write the encoded byte slice.
-    pub(crate) fn put(&mut self, b: &[u8]) -> Result<&mut Self, Error<W::Error>> {
+    ///
+    /// The byte slice may contain a single CBOR item, multiple items or even parts of an item; as
+    /// with maps and arrays, it is up to the caller to eventually provide the right number of
+    /// items.
+    pub fn put(&mut self, b: &[u8]) -> Result<&mut Self, Error<W::Error>> {
         self.writer.write_all(b).map_err(Error::write)?;
         Ok(self)
     }


### PR DESCRIPTION
This makes the Encoder's `.put()` method public, and extends its documentation a bit.

## Motivation

As discussed in https://gitlab.com/twittner/minicbor/-/merge_requests/35, I'm moving the functionality discussed there out into a different crate.

While I originally assumed that that should be possible, I found that the implementation requires a the `.put()` method of the encoder to be public: At this point, the user has data that is encoded in memory as CBOR, and the alternative to copying it into the decoder is to walk it all item by item, dissecting it, just to put it back in in the same way.

I've briefly considered whether this should be an unsafe function, given that the [cboritem](https://crates.io/crates/cboritem) crate this is wrapping treats wellformedness as a type invariant, but given that minicbor makes no unsafe-level promises on the output being wellformed, I don't think that is warranted. (Users can already produce non-wellformed CBOR, eg. by calling `.end()` when no array is open).