### PR TITLE
Support negative indices in maps

### DIFF
--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -121,14 +121,14 @@ impl Attributes {
 
         // #[n(...)]
         if a.path().is_ident("n") {
-            let idx = parse_u32_arg(a).map(Idx::N)?;
+            let idx = parse_i32_arg(a).map(Idx::N)?;
             attrs.try_insert(Kind::Index, Value::Index(idx, a.span()))?;
             return Ok(attrs)
         }
 
         // #[b(...)]
         if a.path().is_ident("b") {
-            let idx = parse_u32_arg(a).map(Idx::B)?;
+            let idx = parse_i32_arg(a).map(Idx::B)?;
             attrs.try_insert(Kind::Index, Value::Index(idx, a.span()))?;
             return Ok(attrs)
         }
@@ -574,11 +574,11 @@ impl Value {
     }
 }
 
-fn parse_u32_arg(a: &syn::Attribute) -> syn::Result<u32> {
+fn parse_i32_arg(a: &syn::Attribute) -> syn::Result<i32> {
     parse_int(&a.parse_args()?)
 }
 
-fn parse_int(n: &syn::LitInt) -> syn::Result<u32> {
-    n.base10_parse().map_err(|_| syn::Error::new(n.span(), "expected `u32` value"))
+fn parse_int(n: &syn::LitInt) -> syn::Result<i32> {
+    n.base10_parse().map_err(|_| syn::Error::new(n.span(), "expected `i32` value"))
 }
 

--- a/minicbor-derive/src/attrs/idx.rs
+++ b/minicbor-derive/src/attrs/idx.rs
@@ -6,14 +6,14 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Idx {
     /// A regular, non-borrowing index.
-    N(u32),
+    N(i32),
     /// An index which indicates that the value borrows from the decoding input.
-    B(u32)
+    B(i32)
 }
 
 impl ToTokens for Idx {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        tokens.append(proc_macro2::Literal::u32_unsuffixed(self.val()))
+        tokens.append(proc_macro2::Literal::i32_unsuffixed(self.val()))
     }
 }
 
@@ -24,11 +24,23 @@ impl Idx {
     }
 
     /// Get the numeric index value.
-    pub fn val(self) -> u32 {
+    pub fn val(self) -> i32 {
         match self {
             Idx::N(i) => i,
             Idx::B(i) => i
         }
+    }
+
+    /// Get a property of the index that is sorted as needed to produce the encoded items:
+    /// They are sorted in their deterministic encoding.
+    ///
+    /// This produces the correct sequence both for CBOR arrays (where all items are emitted in
+    /// ascending order) and for CBOR maps (where keys need to be sorted in bytewise lexicographic
+    /// ordering).
+    ///
+    /// This is used for pre-sorting items for serialization.
+    pub fn val_for_sorting(self) -> impl Ord {
+        (self.val() < 0, self.val().unsigned_abs())
     }
 }
 

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -224,7 +224,7 @@ fn on_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Result
                 }
                 let n: usize = field.index.val()
                     .try_into()
-                    .map_err(|_| syn::Error::new(field.index.span(), "index does not fit into usize"))?;
+                    .map_err(|_| syn::Error::new(field.span(), "index does not fit into usize"))?;
                 let cbor_len = cbor_len(field.attrs.cbor_len(), field.attrs.codec());
                 let is_nil   = is_nil(&field.typ, field.attrs.codec());
                 let ident    = &field.ident;

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -222,9 +222,14 @@ fn on_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Result
                 if field.attrs.skip() {
                     continue
                 }
-                let n: usize = field.index.val()
-                    .try_into()
-                    .map_err(|_| syn::Error::new(field.span(), "index does not fit into usize"))?;
+                let n: usize = field.index.val().try_into()
+                    .map_err(|_| {
+                        if field.index.val().is_negative() {
+                            syn::Error::new(field.span(), "array encoding does not support negative indices")
+                        } else {
+                            syn::Error::new(field.span(), "index does not fit into usize")
+                        }
+                    })?;
                 let cbor_len = cbor_len(field.attrs.cbor_len(), field.attrs.codec());
                 let is_nil   = is_nil(&field.typ, field.attrs.codec());
                 let ident    = &field.ident;

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -362,14 +362,14 @@ fn gen_statements(fields: &Fields, encoding: Encoding) -> syn::Result<proc_macro
 
             if let Some(__len777) = __d777.map()? {
                 for _ in 0 .. __len777 {
-                    match __d777.u32()? {
+                    match __d777.i32()? {
                         #(#indices => #actions)*
                         _          => __d777.skip()?
                     }
                 }
             } else {
                 while minicbor::data::Type::Break != __d777.datatype()? {
-                    match __d777.u32()? {
+                    match __d777.i32()? {
                         #(#indices => #actions)*
                         _          => __d777.skip()?
                     }

--- a/minicbor-derive/src/fields.rs
+++ b/minicbor-derive/src/fields.rs
@@ -28,6 +28,12 @@ pub struct Field {
     pub orig: syn::Field
 }
 
+impl quote::ToTokens for Field {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.orig.to_tokens(tokens)
+    }
+}
+
 impl Fields {
     pub fn try_from<'a, I>(span: Span, iter: I) -> syn::Result<Self>
     where

--- a/minicbor-derive/src/fields.rs
+++ b/minicbor-derive/src/fields.rs
@@ -46,7 +46,7 @@ impl Fields {
             let attrs = Attributes::try_from_iter(Level::Field, &f.attrs)?;
             let index = if attrs.skip() {
                 debug_assert!(attrs.index().is_none());
-                Idx::N(u32::MAX)
+                Idx::N(i32::MAX)
             } else if let Some(i) = attrs.index() {
                 debug_assert!(!attrs.skip());
                 i
@@ -69,7 +69,7 @@ impl Fields {
             }
         }
 
-        fields.sort_unstable_by_key(|f| f.index.val());
+        fields.sort_unstable_by_key(|f| f.index.val_for_sorting());
         idx::check_uniq(span, fields.iter().map(|f| f.index))?;
 
         Ok(Fields { fields, skipped })

--- a/minicbor-tests/tests/encoding.rs
+++ b/minicbor-tests/tests/encoding.rs
@@ -64,7 +64,7 @@ fn encode_as_map() {
     struct T {
         #[n(0)] a: Option<u8>,
         #[n(2)] b: Option<u8>,
-        #[n(5)] c: Option<u8>
+        #[n(-1)] c: Option<u8>
     }
 
     // empty value => empty map
@@ -92,21 +92,21 @@ fn encode_as_map() {
     let v = T { a: Some(1), b: Some(2), c: Some(3) };
 
     let bytes = minicbor::to_vec(&v).unwrap();
-    assert_eq!(&[0xa3, 0, 1, 2, 2, 5, 3][..], &bytes[..]);
+    assert_eq!(&[0xa3, 0, 1, 2, 2, 32 /* -1 */, 3][..], &bytes[..]);
     assert_eq!(v, minicbor::decode(&bytes).unwrap());
 
     // gaps are not encoded
     let v = T { a: Some(1), b: None, c: Some(3) };
 
     let bytes = minicbor::to_vec(&v).unwrap();
-    assert_eq!(&[0xa2, 0, 1, 5, 3][..], &bytes[..]);
+    assert_eq!(&[0xa2, 0, 1, 32 /* -1 */, 3][..], &bytes[..]);
     assert_eq!(v, minicbor::decode(&bytes).unwrap());
 
     // gaps are not encoded
     let v = T { a: None, b: None, c: Some(3) };
 
     let bytes = minicbor::to_vec(&v).unwrap();
-    assert_eq!(&[0xa1, 5, 3][..], &bytes[..]);
+    assert_eq!(&[0xa1, 32 /* -1 */, 3][..], &bytes[..]);
     assert_eq!(v, minicbor::decode(&bytes).unwrap())
 }
 

--- a/minicbor/src/decode/error.rs
+++ b/minicbor/src/decode/error.rs
@@ -98,7 +98,7 @@ impl Error {
 
     /// A value, expected at the given index, was missing.
     #[doc(hidden)]
-    pub fn missing_value(idx: u32) -> Self {
+    pub fn missing_value(idx: i32) -> Self {
         Error {
             err: ErrorImpl::MissingValue(idx),
             pos: None,
@@ -213,7 +213,7 @@ enum ErrorImpl {
     /// An unknown enum variant was encountered.
     UnknownVariant(u32),
     /// A value was missing at the specified index.
-    MissingValue(u32),
+    MissingValue(i32),
     /// Generic error message.
     Message,
     /// Custom error.


### PR DESCRIPTION
Closes: https://github.com/twittner/minicbor/issues/8

---

An existing test was extended to cover the feature, I think this can just work like that.

This does introduce a theoretical regression in that arrays with more than 32k elements now cause trouble (a very theoretical issue) and that maps with keys between 32k and 64k now fail. If you consider those important, I'm happy to extend the numeric range of map keys to i64.

On the side of error handling, so far for where I've tried things, the first error that cropped up when attempting to use a negative integer in an array was always this, which I think is fine:

```
error: proc-macro derive panicked                                          
  --> minicbor-tests/tests/encoding.rs:62:21      
   |
62 |     #[derive(Debug, Encode, Decode, PartialEq, Eq)]                                                                                              
   |                     ^^^^^^
   |                    
   = help: message: Negative index value can only be used as map key, not as array index.: TryFromIntError(())
```