### PR TITLE
Flat enum codec

### DIFF
--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -36,7 +36,8 @@ enum Kind {
     ContextBound,
     CborLen,
     Tag,
-    Skip
+    Skip,
+    Flat,
 }
 
 #[derive(Debug, Clone)]
@@ -53,7 +54,8 @@ enum Value {
     ContextBound(HashSet<syn::TraitBound>, proc_macro2::Span),
     CborLen(syn::ExprPath, proc_macro2::Span),
     Tag(u64, proc_macro2::Span),
-    Skip(proc_macro2::Span)
+    Skip(proc_macro2::Span),
+    Flat(proc_macro2::Span)
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -213,6 +215,8 @@ impl Attributes {
                 attrs.try_insert(Kind::Tag, Value::Tag(i, meta.path.span()))?
             } else if meta.path.is_ident("skip") {
                 attrs.try_insert(Kind::Skip, Value::Skip(meta.path.span()))?
+            } else if meta.path.is_ident("flat") {
+                attrs.try_insert(Kind::Flat, Value::Flat(meta.path.span()))?
             } else {
                 return Err(meta.error("unsupported attribute"))
             }
@@ -262,6 +266,10 @@ impl Attributes {
         self.contains_key(Kind::Skip)
     }
 
+    pub fn flat(&self) -> bool {
+        self.contains_key(Kind::Flat)
+    }
+
     fn contains_key(&self, k: Kind) -> bool {
         self.1.contains_key(&k)
     }
@@ -295,6 +303,7 @@ impl Attributes {
                 | Kind::HasNil
                 | Kind::CborLen
                 | Kind::Skip
+                | Kind::Flat
                 => {
                     let msg = format!("attribute is not supported on {}-level", self.0);
                     return Err(syn::Error::new(val.span(), msg))
@@ -315,6 +324,7 @@ impl Attributes {
                 | Kind::IndexOnly
                 | Kind::Transparent
                 | Kind::ContextBound
+                | Kind::Flat
                 => {
                     let msg = format!("attribute is not supported on {}-level", self.0);
                     return Err(syn::Error::new(val.span(), msg))
@@ -325,6 +335,7 @@ impl Attributes {
                 | Kind::IndexOnly
                 | Kind::ContextBound
                 | Kind::Tag
+                | Kind::Flat
                 => {}
                 | Kind::TypeParam
                 | Kind::Codec
@@ -355,6 +366,7 @@ impl Attributes {
                 | Kind::ContextBound
                 | Kind::CborLen
                 | Kind::Skip
+                | Kind::Flat
                 => {
                     let msg = format!("attribute is not supported on {}-level", self.0);
                     return Err(syn::Error::new(val.span(), msg))
@@ -513,7 +525,8 @@ impl Value {
             Value::ContextBound(_, s) => *s,
             Value::CborLen(_, s)      => *s,
             Value::Tag(_, s)          => *s,
-            Value::Skip(s)            => *s
+            Value::Skip(s)            => *s,
+            Value::Flat(s)            => *s
         }
     }
 

--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -115,6 +115,11 @@ impl Attributes {
                 return Err(syn::Error::new(*s, "`skip` does not allow other attributes"))
             }
         }
+        if let Some(Value::Flat(s)) = this.get(Kind::Flat) {
+            if let Some(Value::Encoding(Encoding::Map, _)) = this.get(Kind::Encoding) {
+                return Err(syn::Error::new(*s, "`flat` does not work with `map`"))
+            }
+        }
         Ok(this)
     }
 

--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -117,7 +117,7 @@ impl Attributes {
         }
         if let Some(Value::Flat(s)) = this.get(Kind::Flat) {
             if let Some(Value::Encoding(Encoding::Map, _)) = this.get(Kind::Encoding) {
-                return Err(syn::Error::new(*s, "`flat` does not work with `map`"))
+                return Err(syn::Error::new(*s, "map encoding does not support `flat`"))
             }
         }
         Ok(this)

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -71,7 +71,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
         return make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)
     }
 
-    let statements = gen_statements(&fields, attrs.encoding().unwrap_or_default())?;
+    let statements = gen_statements(&fields, attrs.encoding().unwrap_or_default(), false)?;
 
     let result = if let syn::Fields::Named(_) = data.fields {
         let nils      = nils(fields.fields());
@@ -127,6 +127,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let enum_attrs    = Attributes::try_from_iter(Level::Enum, inp.attrs.iter())?;
     let enum_encoding = enum_attrs.encoding().unwrap_or_default();
     let index_only    = enum_attrs.index_only();
+    let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter())?;
 
     let mut blacklist = HashSet::new();
@@ -139,7 +140,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         let con = &var.ident;
         let tag = decode_tag(attrs);
         let row = if let syn::Fields::Unit = var.fields {
-            if index_only {
+            if index_only | flat {
                 quote!(#idx => Ok(#name::#con),)
             } else {
                 quote!(#idx => {
@@ -159,7 +160,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             blacklist.extend(collect_type_params(&inp.generics, fields.fields().filter(|f| {
                 f.attrs.codec().map(|c| c.is_decode()).unwrap_or(false)
             })));
-            let statements = gen_statements(&fields, encoding)?;
+            let statements = gen_statements(&fields, encoding, flat)?;
             if let syn::Fields::Named(_) = var.fields {
                 let nils      = nils(fields.fields());
                 let indices   = fields.fields().indices();
@@ -214,6 +215,12 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         quote! {
             let __p778 = __d777.position();
         }
+    } else if flat {
+        quote! {
+            let __p777 = __d777.position();
+            let __len777 =__d777.array()?.expect("variants are arrays under `flat`");
+            let __p778 = __d777.position();
+        }
     } else {
         quote! {
             let __p777 = __d777.position();
@@ -258,7 +265,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 // [1]: These variables will later be deconstructed in `on_enum` and
 // `on_struct` and their inner value will be used to initialise a field.
 // If not present, an error will be produced.
-fn gen_statements(fields: &Fields, encoding: Encoding) -> syn::Result<proc_macro2::TokenStream> {
+fn gen_statements(fields: &Fields, encoding: Encoding, flat: bool) -> syn::Result<proc_macro2::TokenStream> {
     let default_decode_fn: syn::ExprPath = syn::parse_str("minicbor::Decode::decode")?;
 
     let actions = fields.fields().map(|field| {
@@ -335,6 +342,16 @@ fn gen_statements(fields: &Fields, encoding: Encoding) -> syn::Result<proc_macro
     let indices = fields.fields().indices().collect::<Vec<_>>();
 
     Ok(match encoding {
+        Encoding::Array if flat => quote! {
+            #(let mut #idents : core::option::Option<#types> = #inits;)*
+
+            for __i777 in 0 .. __len777-1 {
+                match __i777 {
+                    #(#indices => #actions)*
+                    _          => __d777.skip()?
+                }
+            }
+        },
         Encoding::Array => quote! {
             #(let mut #idents : core::option::Option<#types> = #inits;)*
 

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -218,7 +218,9 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     } else if flat {
         quote! {
             let __p777 = __d777.position();
-            let __len777 =__d777.array()?.expect("variants are arrays under `flat`");
+            let __len777 =__d777.array()?.ok_or(minicbor::decode::Error::message(
+                "variants are definite-length arrays under `flat`"
+            ).at(__p777))?;
             let __p778 = __d777.position();
         }
     } else {

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -221,6 +221,11 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             let __len777 =__d777.array()?.ok_or(minicbor::decode::Error::message(
                 "variants are definite-length arrays under `flat`"
             ).at(__p777))?;
+            if __len777 == 0 {
+                return Err(minicbor::decode::Error::message(
+                    "variants are nonempty arrays under `flat`"
+                ).at(__p777));
+            }
             let __p778 = __d777.position();
         }
     } else {

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -64,7 +64,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     }
 
     let tag = encode_tag(&attrs);
-    let statements = encode_fields(&fields, true, encoding)?;
+    let statements = encode_fields(&fields, true, encoding, false)?.0;
 
     Ok(quote! {
         impl #impl_generics minicbor::Encode<Ctx> for #name #typ_generics #where_clause {
@@ -98,6 +98,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let mut blacklist = HashSet::new();
     let mut field_attrs = Vec::new();
     let mut rows = Vec::new();
+
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
         let fields = Fields::try_from(var.ident.span(), var.fields.iter())?;
         // Collect type parameters which should not have an `Encode` bound added,
@@ -147,13 +148,12 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
             syn::Fields::Named(_) if flat => {
-                let mut num_elems: u32 = 0;
-                let statements = encode_flat_fields(&fields, false, encoding, &mut num_elems)?;
+                let (statements, mut num_fields) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.fields().idents();
-                num_elems += 1;
+                num_fields += 1;
                 quote! {
                     #name::#con{#(#idents,)* ..} => {
-                        __e777.array(#num_elems as u64)?;
+                        __e777.array(#num_fields as u64)?;
                         __e777.u32(#idx)?;
                         #tag
                         #statements
@@ -161,7 +161,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
             syn::Fields::Named(_) => {
-                let statements = encode_fields(&fields, false, encoding)?;
+                let statements = encode_fields(&fields, false, encoding, false)?.0;
                 let idents = fields.fields().idents();
                 quote! {
                     #name::#con{#(#idents,)* ..} => {
@@ -176,13 +176,12 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
             syn::Fields::Unnamed(_) if flat => {
-                let mut num_elems: u32 = 0;
-                let statements = encode_flat_fields(&fields, false, encoding, &mut num_elems)?;
-                num_elems += 1;
+                let (statements, mut num_fields) = encode_fields(&fields, false, encoding, true)?;
+                num_fields += 1;
                 let idents = fields.match_idents();
                 quote! {
                     #name::#con(#(#idents,)*) => {
-                        __e777.array(#num_elems as u64)?;
+                        __e777.array(#num_fields as u64)?;
                         __e777.u32(#idx)?;
                         #tag
                         #statements
@@ -190,7 +189,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
             syn::Fields::Unnamed(_) => {
-                let statements = encode_fields(&fields, false, encoding)?;
+                let statements = encode_fields(&fields, false, encoding, false)?.0;
                 let idents = fields.match_idents();
                 quote! {
                     #name::#con(#(#idents,)*) => {
@@ -256,7 +255,12 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 /// depending on the encoding.
 ///
 /// NB: The `fields` parameter is assumed to be sorted by index.
-fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Result<proc_macro2::TokenStream> {
+fn encode_fields(
+    fields: &Fields,
+    has_self: bool,
+    encoding: Encoding,
+    flat: bool,
+) -> syn::Result<(proc_macro2::TokenStream, u32)> {
     let default_encode_fn: syn::ExprPath = syn::parse_str("minicbor::Encode::encode")?;
 
     let mut tests = Vec::new();
@@ -509,7 +513,18 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Re
         })?;
 
     match encoding {
-        Encoding::Array => Ok(quote! {
+        Encoding::Array if flat => Ok((quote! {
+            let mut __max_index777: core::option::Option<u32> = None;
+
+            #(#tests)*
+
+            if let Some(__i777) = __max_index777 {
+                #(#statements)*
+            }
+
+            Ok(())
+        }, max_fields)),
+        Encoding::Array => Ok((quote! {
             let mut __max_index777: core::option::Option<u32> = None;
 
             #(#tests)*
@@ -522,8 +537,8 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Re
             }
 
             Ok(())
-        }),
-        Encoding::Map => Ok(quote! {
+        }, max_fields)),
+        Encoding::Map => Ok((quote! {
             let mut __max_fields777 = #max_fields;
 
             #(#tests)*
@@ -533,201 +548,7 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Re
             #(#statements)*
 
             Ok(())
-        })
-    }
-}
-
-/// Temporary copy-paste of [encode_fields].
-fn encode_flat_fields(
-    fields: &Fields,
-    has_self: bool, 
-    encoding: Encoding,
-    num_elems: &mut u32,
-) -> syn::Result<proc_macro2::TokenStream> {
-    let default_encode_fn: syn::ExprPath = syn::parse_str("minicbor::Encode::encode")?;
-
-    let mut tests = Vec::new();
-
-    match encoding {
-        // Under array encoding the number of elements is the highest
-        // index + 1. Each value is checked if it is not nil and if so,
-        // the highest index is incremented.
-        Encoding::Array => {
-            for field in fields.fields() {
-                if field.attrs.skip() {
-                    continue
-                }
-                let is_nil = is_nil(&field.typ, field.attrs.codec());
-                let n = field.index.val();
-                let ident = &field.ident;
-                let expr =
-                    if has_self {
-                        if field.is_name {
-                            quote! {
-                                if !#is_nil(&self.#ident) {
-                                    __max_index777 = Some(#n)
-                                }
-                            }
-                        } else {
-                            let i = syn::Index::from(field.pos);
-                            quote! {
-                                if !#is_nil(&self.#i) {
-                                    __max_index777 = Some(#n)
-                                }
-                            }
-                        }
-                    } else {
-                        quote! {
-                            if !#is_nil(&#ident) {
-                                __max_index777 = Some(#n)
-                            }
-                        }
-                    };
-                tests.push(expr)
-            }
-        }
-        // Map encoding is not allowed under `Flat`
-        _ => unreachable!(),
-    }
-
-    let mut statements = Vec::new();
-
-    const IS_NAME: bool = true;
-    const NO_NAME: bool = false;
-    const HAS_SELF: bool = true;
-    const NO_SELF: bool = false;
-    const HAS_GAPS: bool = true;
-    const NO_GAPS: bool = false;
-
-    match encoding {
-        // Under array encoding only field values are encoded and their
-        // index is represented as the array position. Gaps between indexes
-        // need to be filled with null.
-        Encoding::Array => {
-            let mut first = true;
-            let mut k = 0;
-            for field in fields.fields() {
-                if field.attrs.skip() {
-                    continue
-                }
-                let encode_fn = field.attrs.codec().as_ref()
-                    .and_then(|f| f.to_encode_path())
-                    .unwrap_or_else(|| default_encode_fn.clone());
-                let tag = encode_tag(&field.attrs);
-                let idx = &field.index;
-                let gaps = if first {
-                    first = false;
-                    idx.val() - k
-                } else {
-                    idx.val() - k - 1
-                };
-                let ident = &field.ident;
-                let statement =
-                    match (field.is_name, has_self, gaps > 0) {
-                        // struct
-                        (IS_NAME, HAS_SELF, HAS_GAPS) => quote! {
-                            if #idx <= __i777 {
-                                for _ in 0 .. #gaps {
-                                    __e777.null()?;
-                                }
-                                #tag
-                                #encode_fn(&self.#ident, __e777, __ctx777)?
-                            }
-                        },
-                        (IS_NAME, HAS_SELF, NO_GAPS) => quote! {
-                            if #idx <= __i777 {
-                                #tag
-                                #encode_fn(&self.#ident, __e777, __ctx777)?
-                            }
-                        },
-                        // enum struct
-                        (IS_NAME, NO_SELF, HAS_GAPS) => quote! {
-                            if #idx <= __i777 {
-                                for _ in 0 .. #gaps {
-                                    __e777.null()?;
-                                }
-                                #tag
-                                #encode_fn(#ident, __e777, __ctx777)?
-                            }
-                        },
-                        (IS_NAME, NO_SELF, NO_GAPS) => quote! {
-                            if #idx <= __i777 {
-                                #tag
-                                #encode_fn(#ident, __e777, __ctx777)?
-                            }
-                        },
-                        // tuple struct
-                        (NO_NAME, HAS_SELF, HAS_GAPS) => {
-                            let i = syn::Index::from(field.pos);
-                            quote! {
-                                if #idx <= __i777 {
-                                    for _ in 0 .. #gaps {
-                                        __e777.null()?;
-                                    }
-                                    #tag
-                                    #encode_fn(&self.#i, __e777, __ctx777)?
-                                }
-                            }
-                        }
-                        (NO_NAME, HAS_SELF, NO_GAPS) => {
-                            let i = syn::Index::from(field.pos);
-                            quote! {
-                                if #idx <= __i777 {
-                                    #tag
-                                    #encode_fn(&self.#i, __e777, __ctx777)?
-                                }
-                            }
-                         }
-                        // enum tuple
-                        (NO_NAME, NO_SELF, HAS_GAPS) => quote! {
-                            if #idx <= __i777 {
-                                for _ in 0 .. #gaps {
-                                    __e777.null()?;
-                                }
-                                #tag
-                                #encode_fn(#ident, __e777, __ctx777)?
-                            }
-                        },
-                        (NO_NAME, NO_SELF, NO_GAPS) => quote! {
-                            if #idx <= __i777 {
-                                #tag
-                                #encode_fn(#ident, __e777, __ctx777)?
-                            }
-                        }
-                    };
-                statements.push(statement);
-                k = idx.val()
-            }
-        }
-        // Map encoding is not allowed under `Flat`
-        _ => unreachable!(),
-    }
-    
-    let max_fields: u32 = fields.fields().len().try_into()
-        .map_err(|_| {
-            let msg = "more than 2^32 fields are not supported";
-            syn::Error::new(proc_macro2::Span::call_site(), msg)
-        })?;
-
-    *num_elems = max_fields;
-    
-    match encoding {
-        Encoding::Array => Ok(quote! {
-            let mut __max_index777: core::option::Option<u32> = None;
-
-            #(#tests)*
-
-            if let Some(__i777) = __max_index777 {
-                // __e777.array(u64::from(__i777) + 1)?;
-                #(#statements)*
-            // } else {
-            //     __e777.array(0)?;
-            }
-
-            Ok(())
-        }),
-        // Map encoding is not allowed under `Flat`
-        _ => unreachable!(),
+        }, max_fields)),
     }
 }
 

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -92,6 +92,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let enum_attrs    = Attributes::try_from_iter(Level::Enum, inp.attrs.iter())?;
     let enum_encoding = enum_attrs.encoding().unwrap_or_default();
     let index_only    = enum_attrs.index_only();
+    let flat         = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter())?;
 
     let mut blacklist = HashSet::new();
@@ -112,6 +113,14 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 Encoding::Array | Encoding::Map if index_only => quote! {
                     #name::#con => {
                         __e777.u32(#idx)?;
+                        Ok(())
+                    }
+                },
+                Encoding::Array if flat => quote! {
+                    #name::#con => {
+                        __e777.array(1)?;
+                        __e777.u32(#idx)?;
+                       // #tag
                         Ok(())
                     }
                 },
@@ -137,6 +146,20 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             syn::Fields::Named(f) if index_only => {
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
+            syn::Fields::Named(_) if flat => {
+                let mut num_elems: u32 = 0;
+                let statements = encode_flat_fields(&fields, false, encoding, &mut num_elems)?;
+                let idents = fields.fields().idents();
+                num_elems += 1;
+                quote! {
+                    #name::#con{#(#idents,)* ..} => {
+                        __e777.array(#num_elems as u64)?;
+                        __e777.u32(#idx)?;
+                        #tag
+                        #statements
+                    }
+                }
+            }
             syn::Fields::Named(_) => {
                 let statements = encode_fields(&fields, false, encoding)?;
                 let idents = fields.fields().idents();
@@ -151,6 +174,20 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             }
             syn::Fields::Unnamed(f) if index_only => {
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
+            }
+            syn::Fields::Unnamed(_) if flat => {
+                let mut num_elems: u32 = 0;
+                let statements = encode_flat_fields(&fields, false, encoding, &mut num_elems)?;
+                num_elems += 1;
+                let idents = fields.match_idents();
+                quote! {
+                    #name::#con(#(#idents,)*) => {
+                        __e777.array(#num_elems as u64)?;
+                        __e777.u32(#idx)?;
+                        #tag
+                        #statements
+                    }
+                }
             }
             syn::Fields::Unnamed(_) => {
                 let statements = encode_fields(&fields, false, encoding)?;
@@ -497,6 +534,200 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Re
 
             Ok(())
         })
+    }
+}
+
+/// Temporary copy-paste of [encode_fields].
+fn encode_flat_fields(
+    fields: &Fields,
+    has_self: bool, 
+    encoding: Encoding,
+    num_elems: &mut u32,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let default_encode_fn: syn::ExprPath = syn::parse_str("minicbor::Encode::encode")?;
+
+    let mut tests = Vec::new();
+
+    match encoding {
+        // Under array encoding the number of elements is the highest
+        // index + 1. Each value is checked if it is not nil and if so,
+        // the highest index is incremented.
+        Encoding::Array => {
+            for field in fields.fields() {
+                if field.attrs.skip() {
+                    continue
+                }
+                let is_nil = is_nil(&field.typ, field.attrs.codec());
+                let n = field.index.val();
+                let ident = &field.ident;
+                let expr =
+                    if has_self {
+                        if field.is_name {
+                            quote! {
+                                if !#is_nil(&self.#ident) {
+                                    __max_index777 = Some(#n)
+                                }
+                            }
+                        } else {
+                            let i = syn::Index::from(field.pos);
+                            quote! {
+                                if !#is_nil(&self.#i) {
+                                    __max_index777 = Some(#n)
+                                }
+                            }
+                        }
+                    } else {
+                        quote! {
+                            if !#is_nil(&#ident) {
+                                __max_index777 = Some(#n)
+                            }
+                        }
+                    };
+                tests.push(expr)
+            }
+        }
+        // Map encoding is not allowed under `Flat`
+        _ => todo!(),
+    }
+
+    let mut statements = Vec::new();
+
+    const IS_NAME: bool = true;
+    const NO_NAME: bool = false;
+    const HAS_SELF: bool = true;
+    const NO_SELF: bool = false;
+    const HAS_GAPS: bool = true;
+    const NO_GAPS: bool = false;
+
+    match encoding {
+        // Under array encoding only field values are encoded and their
+        // index is represented as the array position. Gaps between indexes
+        // need to be filled with null.
+        Encoding::Array => {
+            let mut first = true;
+            let mut k = 0;
+            for field in fields.fields() {
+                if field.attrs.skip() {
+                    continue
+                }
+                let encode_fn = field.attrs.codec().as_ref()
+                    .and_then(|f| f.to_encode_path())
+                    .unwrap_or_else(|| default_encode_fn.clone());
+                let tag = encode_tag(&field.attrs);
+                let idx = &field.index;
+                let gaps = if first {
+                    first = false;
+                    idx.val() - k
+                } else {
+                    idx.val() - k - 1
+                };
+                let ident = &field.ident;
+                let statement =
+                    match (field.is_name, has_self, gaps > 0) {
+                        // struct
+                        (IS_NAME, HAS_SELF, HAS_GAPS) => quote! {
+                            if #idx <= __i777 {
+                                for _ in 0 .. #gaps {
+                                    __e777.null()?;
+                                }
+                                #tag
+                                #encode_fn(&self.#ident, __e777, __ctx777)?
+                            }
+                        },
+                        (IS_NAME, HAS_SELF, NO_GAPS) => quote! {
+                            if #idx <= __i777 {
+                                #tag
+                                #encode_fn(&self.#ident, __e777, __ctx777)?
+                            }
+                        },
+                        // enum struct
+                        (IS_NAME, NO_SELF, HAS_GAPS) => quote! {
+                            if #idx <= __i777 {
+                                for _ in 0 .. #gaps {
+                                    __e777.null()?;
+                                }
+                                #tag
+                                #encode_fn(#ident, __e777, __ctx777)?
+                            }
+                        },
+                        (IS_NAME, NO_SELF, NO_GAPS) => quote! {
+                            if #idx <= __i777 {
+                                #tag
+                                #encode_fn(#ident, __e777, __ctx777)?
+                            }
+                        },
+                        // tuple struct
+                        (NO_NAME, HAS_SELF, HAS_GAPS) => {
+                            let i = syn::Index::from(field.pos);
+                            quote! {
+                                if #idx <= __i777 {
+                                    for _ in 0 .. #gaps {
+                                        __e777.null()?;
+                                    }
+                                    #tag
+                                    #encode_fn(&self.#i, __e777, __ctx777)?
+                                }
+                            }
+                        }
+                        (NO_NAME, HAS_SELF, NO_GAPS) => {
+                            let i = syn::Index::from(field.pos);
+                            quote! {
+                                if #idx <= __i777 {
+                                    #tag
+                                    #encode_fn(&self.#i, __e777, __ctx777)?
+                                }
+                            }
+                         }
+                        // enum tuple
+                        (NO_NAME, NO_SELF, HAS_GAPS) => quote! {
+                            if #idx <= __i777 {
+                                for _ in 0 .. #gaps {
+                                    __e777.null()?;
+                                }
+                                #tag
+                                #encode_fn(#ident, __e777, __ctx777)?
+                            }
+                        },
+                        (NO_NAME, NO_SELF, NO_GAPS) => quote! {
+                            if #idx <= __i777 {
+                                #tag
+                                #encode_fn(#ident, __e777, __ctx777)?
+                            }
+                        }
+                    };
+                statements.push(statement);
+                k = idx.val()
+            }
+        }
+        // Map encoding is not allowed under `Flat`
+        _ => todo!(),
+    }
+    
+    let max_fields: u32 = fields.fields().len().try_into()
+        .map_err(|_| {
+            let msg = "more than 2^32 fields are not supported";
+            syn::Error::new(proc_macro2::Span::call_site(), msg)
+        })?;
+
+    *num_elems = max_fields;
+    
+    match encoding {
+        Encoding::Array => Ok(quote! {
+            let mut __max_index777: core::option::Option<u32> = None;
+
+            #(#tests)*
+
+            if let Some(__i777) = __max_index777 {
+                // __e777.array(u64::from(__i777) + 1)?;
+                #(#statements)*
+            // } else {
+            //     __e777.array(0)?;
+            }
+
+            Ok(())
+        }),
+        // Map encoding is not allowed under `Flat`
+        _ => todo!(),
     }
 }
 

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -587,7 +587,7 @@ fn encode_flat_fields(
             }
         }
         // Map encoding is not allowed under `Flat`
-        _ => todo!(),
+        _ => unreachable!(),
     }
 
     let mut statements = Vec::new();
@@ -700,7 +700,7 @@ fn encode_flat_fields(
             }
         }
         // Map encoding is not allowed under `Flat`
-        _ => todo!(),
+        _ => unreachable!(),
     }
     
     let max_fields: u32 = fields.fields().len().try_into()
@@ -727,7 +727,7 @@ fn encode_flat_fields(
             Ok(())
         }),
         // Map encoding is not allowed under `Flat`
-        _ => todo!(),
+        _ => unreachable!(),
     }
 }
 

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -152,14 +152,15 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             syn::Fields::Named(f) if index_only => {
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
-            syn::Fields::Named(_) if flat => {
+            syn::Fields::Named(f) if flat => {
                 let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.fields().idents();
+                let not_empty: u32 = (!f.named.is_empty()).into();
                 quote! {
                     #name::#con{#(#idents,)* ..} => {
                         #tests
-                        // Adding 2 to get size (enum index and 0-based indexing).
-                        let __size777 = __max_index777.unwrap_or_default() as u64 + 2;
+                        // Get array size considering the enum index and 0-based indexing.
+                        let __size777 = (__max_index777.unwrap_or_default() + 1 + #not_empty) as u64;
                         __e777.array(__size777)?;
                         __e777.u32(#idx)?;
                         #statements
@@ -182,14 +183,15 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             syn::Fields::Unnamed(f) if index_only => {
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
-            syn::Fields::Unnamed(_) if flat => {
+            syn::Fields::Unnamed(f) if flat => {
                 let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.match_idents();
+                let not_empty: u32 = (!f.unnamed.is_empty()).into();
                 quote! {
                     #name::#con(#(#idents,)*) => {
                         #tests
-                        // Adding 2 to get size (enum index and 0-based indexing).
-                        let __size777 = __max_index777.unwrap_or_default() as u64 + 2;
+                        // Get array size considering the enum index and 0-based indexing.
+                        let __size777 = (__max_index777.unwrap_or_default() + 1 + #not_empty) as u64;
                         __e777.array(__size777)?;
                         __e777.u32(#idx)?;
                         #statements

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -118,11 +118,16 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         Ok(())
                     }
                 },
+                Encoding::Array if flat & attrs.tag().is_some() => quote! {
+                    #name::#con => {
+                        Err(msg("tags are not allowed for `flat` variants with no fields"))
+                    }
+                },
                 Encoding::Array if flat => quote! {
                     #name::#con => {
                         __e777.array(1)?;
                         __e777.u32(#idx)?;
-                        #tag
+
                         Ok(())
                     }
                 },
@@ -164,7 +169,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
             syn::Fields::Named(_) => {
-                let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
+                let (tests, statements) = encode_fields(&fields, false, encoding, false)?;
                 let idents = fields.fields().idents();
                 quote! {
                     #name::#con{#(#idents,)* ..} => {
@@ -195,7 +200,8 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
             syn::Fields::Unnamed(_) => {
-                let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
+                let (tests, statements) = encode_fields(&fields, false, encoding, false)?;
+
                 let idents = fields.match_idents();
                 quote! {
                     #name::#con(#(#idents,)*) => {

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -64,7 +64,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     }
 
     let tag = encode_tag(&attrs);
-    let statements = encode_fields(&fields, true, encoding, false)?.0;
+    let (tests, statements) = encode_fields(&fields, true, encoding, false)?;
 
     Ok(quote! {
         impl #impl_generics minicbor::Encode<Ctx> for #name #typ_generics #where_clause {
@@ -73,6 +73,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
                 __W777: minicbor::encode::Write
             {
                 #tag
+                #tests
                 #statements
             }
         }

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -93,7 +93,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let enum_attrs    = Attributes::try_from_iter(Level::Enum, inp.attrs.iter())?;
     let enum_encoding = enum_attrs.encoding().unwrap_or_default();
     let index_only    = enum_attrs.index_only();
-    let flat         = enum_attrs.flat();
+    let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter())?;
 
     let mut blacklist = HashSet::new();
@@ -118,7 +118,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         Ok(())
                     }
                 },
-                Encoding::Array if flat & attrs.tag().is_some() => quote! {
+                Encoding::Array if flat && attrs.tag().is_some() => quote! {
                     #name::#con => {
                         Err(msg("tags are not allowed for `flat` variants with no fields"))
                     }
@@ -127,7 +127,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     #name::#con => {
                         __e777.array(1)?;
                         __e777.u32(#idx)?;
-
                         Ok(())
                     }
                 },
@@ -163,7 +162,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         let __size777 = __max_index777.unwrap_or_default() as u64 + 2;
                         __e777.array(__size777)?;
                         __e777.u32(#idx)?;
-                        #tag
                         #statements
                     }
                 }
@@ -194,7 +192,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         let __size777 = __max_index777.unwrap_or_default() as u64 + 2;
                         __e777.array(__size777)?;
                         __e777.u32(#idx)?;
-                        #tag
                         #statements
                     }
                 }

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -121,7 +121,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     #name::#con => {
                         __e777.array(1)?;
                         __e777.u32(#idx)?;
-                       // #tag
+                        #tag
                         Ok(())
                     }
                 },
@@ -148,12 +148,14 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
             syn::Fields::Named(_) if flat => {
-                let (statements, mut num_fields) = encode_fields(&fields, false, encoding, true)?;
+                let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.fields().idents();
-                num_fields += 1;
                 quote! {
                     #name::#con{#(#idents,)* ..} => {
-                        __e777.array(#num_fields as u64)?;
+                        #tests
+                        // Adding 2 to get size (enum index and 0-based indexing).
+                        let __size777 = __max_index777.unwrap_or_default() as u64 + 2;
+                        __e777.array(__size777)?;
                         __e777.u32(#idx)?;
                         #tag
                         #statements
@@ -161,10 +163,11 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
             syn::Fields::Named(_) => {
-                let statements = encode_fields(&fields, false, encoding, false)?.0;
+                let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.fields().idents();
                 quote! {
                     #name::#con{#(#idents,)* ..} => {
+                        #tests
                         __e777.array(2)?;
                         __e777.u32(#idx)?;
                         #tag
@@ -176,12 +179,14 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 return Err(syn::Error::new(f.span(), "index_only enums must not have fields"))
             }
             syn::Fields::Unnamed(_) if flat => {
-                let (statements, mut num_fields) = encode_fields(&fields, false, encoding, true)?;
-                num_fields += 1;
+                let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.match_idents();
                 quote! {
                     #name::#con(#(#idents,)*) => {
-                        __e777.array(#num_fields as u64)?;
+                        #tests
+                        // Adding 2 to get size (enum index and 0-based indexing).
+                        let __size777 = __max_index777.unwrap_or_default() as u64 + 2;
+                        __e777.array(__size777)?;
                         __e777.u32(#idx)?;
                         #tag
                         #statements
@@ -189,10 +194,11 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
             syn::Fields::Unnamed(_) => {
-                let statements = encode_fields(&fields, false, encoding, false)?.0;
+                let (tests, statements) = encode_fields(&fields, false, encoding, true)?;
                 let idents = fields.match_idents();
                 quote! {
                     #name::#con(#(#idents,)*) => {
+                        #tests
                         __e777.array(2)?;
                         __e777.u32(#idx)?;
                         #tag
@@ -260,7 +266,7 @@ fn encode_fields(
     has_self: bool,
     encoding: Encoding,
     flat: bool,
-) -> syn::Result<(proc_macro2::TokenStream, u32)> {
+) -> syn::Result<(proc_macro2::TokenStream, proc_macro2::TokenStream)> {
     let default_encode_fn: syn::ExprPath = syn::parse_str("minicbor::Encode::encode")?;
 
     let mut tests = Vec::new();
@@ -513,42 +519,51 @@ fn encode_fields(
         })?;
 
     match encoding {
-        Encoding::Array if flat => Ok((quote! {
-            let mut __max_index777: core::option::Option<u32> = None;
+        Encoding::Array if flat => Ok((
+            quote! {
+                let mut __max_index777: core::option::Option<u32> = None;
 
-            #(#tests)*
+                #(#tests)*
+            },
+            quote! {
+                if let Some(__i777) = __max_index777 {
+                    #(#statements)*
+                }
 
-            if let Some(__i777) = __max_index777 {
-                #(#statements)*
+                Ok(())
             }
+        )),
+        Encoding::Array => Ok((
+            quote! {
+                let mut __max_index777: core::option::Option<u32> = None;
 
-            Ok(())
-        }, max_fields)),
-        Encoding::Array => Ok((quote! {
-            let mut __max_index777: core::option::Option<u32> = None;
+                #(#tests)*
+            },
+            quote! {
+                if let Some(__i777) = __max_index777 {
+                    __e777.array(u64::from(__i777) + 1)?;
+                    #(#statements)*
+                } else {
+                    __e777.array(0)?;
+                }
 
-            #(#tests)*
-
-            if let Some(__i777) = __max_index777 {
-                __e777.array(u64::from(__i777) + 1)?;
-                #(#statements)*
-            } else {
-                __e777.array(0)?;
+                Ok(())
             }
+        )),
+        Encoding::Map => Ok((
+            quote! {
+                let mut __max_fields777 = #max_fields;
 
-            Ok(())
-        }, max_fields)),
-        Encoding::Map => Ok((quote! {
-            let mut __max_fields777 = #max_fields;
+                #(#tests)*
+            },
+            quote! {
+                __e777.map(u64::from(__max_fields777))?;
 
-            #(#tests)*
+                #(#statements)*
 
-            __e777.map(u64::from(__max_fields777))?;
-
-            #(#statements)*
-
-            Ok(())
-        }, max_fields)),
+                Ok(())
+            }
+        )),
     }
 }
 

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -107,6 +107,12 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         blacklist.extend(collect_type_params(&inp.generics, fields.fields().filter(|f| {
             f.attrs.codec().map(|c| c.is_encode()).unwrap_or(false)
         })));
+        if flat && attrs.tag().is_some() {
+            return Err(syn::Error::new(
+                var.ident.span(),
+                "tags are not allowed for variants under `flat`",
+            ))
+        };
         let con = &var.ident;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let tag = encode_tag(attrs);
@@ -116,11 +122,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     #name::#con => {
                         __e777.u32(#idx)?;
                         Ok(())
-                    }
-                },
-                Encoding::Array if flat && attrs.tag().is_some() => quote! {
-                    #name::#con => {
-                        Err(msg("tags are not allowed for `flat` variants with no fields"))
                     }
                 },
                 Encoding::Array if flat => quote! {

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -144,6 +144,13 @@
 //! them. This changes the encoding to encode only the variant index (cf. section
 //! [CBOR encoding](#cbor-encoding) for details).
 //!
+//! ## `#[cbor(flat)]`
+//!
+//! This attribute can be attached to enums. It provides with a "shallow" encoding,
+//! in such a way that each variant is a encoded as a variable-sized array
+//! containing as its first element the index of the enum, and further elements
+//! correspond to the enum fields in order.
+//!
 //! ## `#[cbor(transparent)]`
 //!
 //! This attribute can be attached to structs with exactly one field (aka newtypes).
@@ -431,7 +438,8 @@
 //! ## Enums
 //!
 //! Unless the [`#[cbor(index_only)]`](#cborindex_only) attribute is used for
-//! enums without any fields, each enum variant is encoded as a two-element
+//! enums without any fields (or [`#[cbor(flat)]`](#cborflat) is in use),
+//! each enum variant is encoded as a two-element
 //! array. The first element is the variant index and the second the actual
 //! variant value. Otherwise, if enums do not have fields and the `index_only`
 //! attribute is present, only the variant index is encoded:
@@ -440,8 +448,11 @@
 //! <<enum encoding>> =
 //!     | `array(2)` n <<struct-as-array encoding>> ; if #[cbor(array)]
 //!     | `array(2)` n <<struct-as-map encoding>>   ; if #[cbor(map)]
+//!     | `array(k)` n <<field encoding>>*          ; if #[cbor(flat)]
 //!     | n                                         ; if #[cbor(index_only)]
 //! ```
+//!
+//! Above, `k` is the number of variant fields plus one.
 //!
 //! ## Which encoding to use?
 //!


### PR DESCRIPTION
This PR implements the `flat` attribute, intended to be used with enums.

It provides with a "shallow" encoding, in such a way that each variant is a encoded as a variable-sized array containing as its first element the index of the enum variant, and further elements correspond to the enum fields in order.

# Example

So, for instance, the following code block
```rust
#[derive(Encode, Decode, Debug, Clone, PartialEq)]
#[cbor(flat)]
pub enum BlockQuery {
    #[n(0)]
    GetLedgerTip,
    #[n(1)]
    GetEpochNo(#[n(0)] Vec<u8>, #[n(1)] u32),
    #[n(2)]
    GetNonMyopicMemberRewards(#[n(0)] u32),
    #[n(3)]
    GetCurrentPParams,
    #[n(4)]
    GetProposedPParamsUpdates,
    #[n(5)]
    GetStakeDistribution,
    #[n(6)]
    GetThing { #[n(0)] foo: u32, #[n(1)] bar: Option<bool>, },
}
```
generates the following encodings:
- `GetStakeDistribution` is encoded as `8105`;
- `GetNonMyopicMemberRewards(10)` is encoded as `82020a`;
- `GetEpochNo(vec![3, 3], 15)` is encoded as `83018203030f`; and
- `GetThing{ foo:11, bar: Some(false) }` is encoded as `83060bf4`.

# Motivation

The original motivation for this feature is the extended use of this encoding of enumerations in the Cardano blockchain (from which some of the names above were taken, and can be seen live at [this fork branch](https://github.com/sterraf/pallas/blob/b05a9966c9b1a6f88c5606bad0e1819af228ca0f/pallas-network/src/miniprotocols/localstate/queries_v16/mod.rs#L28-L31) of the Pallas backend).

# About function types (inner API)

This implementation modified the type of the `get_statements` function (by adding a Boolean argument) and `encode_fields` (by adding the same argument, and by splitting its returning value in tests and statements).

I hope I was respectful enough to the overall code philosophy of the project. 