### PR TITLE
Add "borrow" attribute.

### DIFF
--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -5,7 +5,7 @@ pub mod codec;
 pub mod encoding;
 pub mod idx;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, BTreeSet};
 use std::fmt;
 use std::hash::Hash;
 use std::iter;
@@ -24,6 +24,7 @@ pub struct Attributes(Level, HashMap<Kind, Value>);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum Kind {
+    Borrow,
     Codec,
     Encoding,
     Index,
@@ -41,6 +42,7 @@ enum Kind {
 
 #[derive(Debug, Clone)]
 enum Value {
+    Borrow(BTreeSet<syn::Lifetime>, proc_macro2::Span),
     Codec(CustomCodec, proc_macro2::Span),
     Encoding(Encoding, proc_macro2::Span),
     Index(Idx, proc_macro2::Span),
@@ -167,6 +169,15 @@ impl Attributes {
                 let s: LitStr = meta.value()?.parse()?;
                 let c = CustomCodec::Module(s.parse()?, false);
                 attrs.try_insert(Kind::Codec, Value::Codec(c, meta.path.span()))?
+            } else if meta.path.is_ident("borrow") {
+                let mut l = BTreeSet::new();
+                if meta.input.peek(syn::Token!(=)) {
+                    let s: LitStr = meta.value()?.parse()?;
+                    for b in s.value().split('+').filter(|b| !b.is_empty()) {
+                        l.insert(syn::parse_str::<syn::Lifetime>(b.trim())?);
+                    }
+                }
+                attrs.try_insert(Kind::Borrow, Value::Borrow(l, meta.path.span()))?
             } else if meta.path.is_ident("encode_bound") {
                 let s: LitStr = meta.value()?.parse()?;
                 let t: syn::TypeParam = s.parse()?;
@@ -220,6 +231,10 @@ impl Attributes {
         })?;
 
         Ok(attrs)
+    }
+
+    pub fn borrow(&self) -> Option<&BTreeSet<syn::Lifetime>> {
+        self.get(Kind::Borrow).and_then(|v| v.borrow())
     }
 
     pub fn encoding(&self) -> Option<Encoding> {
@@ -286,6 +301,7 @@ impl Attributes {
                 | Kind::ContextBound
                 | Kind::Tag
                 => {}
+                | Kind::Borrow
                 | Kind::TypeParam
                 | Kind::Codec
                 | Kind::Index
@@ -302,6 +318,7 @@ impl Attributes {
             }
             Level::Field => match key {
                 | Kind::TypeParam
+                | Kind::Borrow
                 | Kind::Codec
                 | Kind::Index
                 | Kind::Nil
@@ -326,6 +343,7 @@ impl Attributes {
                 | Kind::ContextBound
                 | Kind::Tag
                 => {}
+                | Kind::Borrow
                 | Kind::TypeParam
                 | Kind::Codec
                 | Kind::Index
@@ -345,6 +363,7 @@ impl Attributes {
                 | Kind::Index
                 | Kind::Tag
                 => {}
+                | Kind::Borrow
                 | Kind::TypeParam
                 | Kind::Codec
                 | Kind::IndexOnly
@@ -491,6 +510,18 @@ impl Attributes {
                     }
                 }
             }
+            Value::Borrow(_, s) => {
+                if let Some(idx) = self.index() {
+                    if idx.is_b() {
+                        return Err(syn::Error::new(*s, "`borrow` and `b` are mutually exclusive"))
+                    }
+                }
+            }
+            Value::Index(idx, s) if idx.is_b() => {
+                if self.contains_key(Kind::Borrow) {
+                    return Err(syn::Error::new(*s, "`b` and `borrow` are mutually exclusive"))
+                }
+            }
             _ => {}
         }
         self.1.insert(key, val);
@@ -501,6 +532,7 @@ impl Attributes {
 impl Value {
     fn span(&self) -> proc_macro2::Span {
         match self {
+            Value::Borrow(_, s)       => *s,
             Value::TypeParam(_, s)    => *s,
             Value::Codec(_, s)        => *s,
             Value::Encoding(_, s)     => *s,
@@ -514,6 +546,14 @@ impl Value {
             Value::CborLen(_, s)      => *s,
             Value::Tag(_, s)          => *s,
             Value::Skip(s)            => *s
+        }
+    }
+
+    fn borrow(&self) -> Option<&BTreeSet<syn::Lifetime>> {
+        if let Value::Borrow(l, _) = self {
+            Some(l)
+        } else {
+            None
         }
     }
 

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -28,7 +28,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
 
     let name   = &inp.ident;
     let attrs  = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
-    let fields = Fields::try_from(name.span(), data.fields.iter())?;
+    let fields = Fields::try_from(name.span(), data.fields.iter(), &attrs)?;
 
     let cbor_len_bound = gen_cbor_len_bound()?;
     let encode_bound   = gen_encode_bound()?;
@@ -82,7 +82,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 
     let mut rows = Vec::new();
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
-        let fields   = Fields::try_from(var.ident.span(), var.fields.iter())?;
+        let fields   = Fields::try_from(var.ident.span(), var.fields.iter(), &enum_attrs)?;
         let con      = &var.ident;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let tag      = on_tag(attrs);

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -34,7 +34,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
 
     let name   = &inp.ident;
     let attrs  = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
-    let fields = Fields::try_from(name.span(), data.fields.iter())?;
+    let fields = Fields::try_from(name.span(), data.fields.iter(), &attrs)?;
 
     let mut lifetime = gen_lifetime()?;
     for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, f.attrs.borrow(), &f.typ))) {
@@ -134,7 +134,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let mut lifetime = gen_lifetime()?;
     let mut rows = Vec::new();
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
-        let fields = Fields::try_from(var.ident.span(), var.fields.iter())?;
+        let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &enum_attrs)?;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let con = &var.ident;
         let tag = decode_tag(attrs);

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -37,7 +37,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     let fields = Fields::try_from(name.span(), data.fields.iter())?;
 
     let mut lifetime = gen_lifetime()?;
-    for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, &f.typ))) {
+    for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, f.attrs.borrow(), &f.typ))) {
         if !lifetime.bounds.iter().any(|b| *b == l) {
             lifetime.bounds.push(l.clone())
         }
@@ -149,7 +149,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 })
             }
         } else {
-            for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, &f.typ))) {
+            for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, f.attrs.borrow(), &f.typ))) {
                 if !lifetime.bounds.iter().any(|b| *b == l) {
                     lifetime.bounds.push(l.clone())
                 }
@@ -296,7 +296,7 @@ fn gen_statements(fields: &Fields, encoding: Encoding) -> syn::Result<proc_macro
 
             let value =
                 if cfg!(any(feature = "alloc", feature = "std"))
-                    && field.index.is_b()
+                    && (field.attrs.borrow().is_some() || field.index.is_b())
                     && is_cow(&field.typ, |t| is_str(t) || is_byte_slice(t))
                 {
                     if cfg!(feature = "std") {
@@ -398,7 +398,7 @@ fn make_transparent_impl
 
     let call =
         if cfg!(any(feature = "alloc", feature = "std"))
-            && field.index.is_b()
+            && (field.attrs.borrow().is_some() || field.index.is_b())
             && is_cow(&field.typ, |t| is_str(t) || is_byte_slice(t))
         {
             let cow =

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -34,7 +34,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     let name     = &inp.ident;
     let attrs    = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
     let encoding = attrs.encoding().unwrap_or_default();
-    let fields   = Fields::try_from(name.span(), data.fields.iter())?;
+    let fields   = Fields::try_from(name.span(), data.fields.iter(), &attrs)?;
 
     // Collect type parameters which should not have an `Encode` bound added,
     // i.e. from fields which have a custom encode function defined.
@@ -98,7 +98,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let mut field_attrs = Vec::new();
     let mut rows = Vec::new();
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
-        let fields = Fields::try_from(var.ident.span(), var.fields.iter())?;
+        let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &enum_attrs)?;
         // Collect type parameters which should not have an `Encode` bound added,
         // i.e. from fields which have a custom encode function defined.
         blacklist.extend(collect_type_params(&inp.generics, fields.fields().filter(|f| {

--- a/minicbor-derive/src/fields.rs
+++ b/minicbor-derive/src/fields.rs
@@ -35,7 +35,7 @@ impl quote::ToTokens for Field {
 }
 
 impl Fields {
-    pub fn try_from<'a, I>(span: Span, iter: I) -> syn::Result<Self>
+    pub fn try_from<'a, I>(span: Span, iter: I, parent: &Attributes) -> syn::Result<Self>
     where
         I: IntoIterator<Item = &'a syn::Field>
     {
@@ -50,6 +50,8 @@ impl Fields {
             } else if let Some(i) = attrs.index() {
                 debug_assert!(!attrs.skip());
                 i
+            } else if parent.transparent() {
+                Idx::N(i32::MAX)
             } else {
                 let s = f.ident.as_ref().map(|i| i.span()).unwrap_or_else(|| f.ty.span());
                 return Err(syn::Error::new(s, "missing `#[n(...)]` or `#[b(...)]` attribute"))

--- a/minicbor-derive/src/lifetimes.rs
+++ b/minicbor-derive/src/lifetimes.rs
@@ -1,6 +1,7 @@
+use std::collections::BTreeSet;
+
 use crate::{is_str, is_byte_slice};
 use crate::attrs::Idx;
-use std::collections::HashSet;
 
 /// Generate the decode lifetime.
 pub fn gen_lifetime() -> syn::Result<syn::LifetimeParam> {
@@ -16,9 +17,9 @@ pub fn add_lifetime(g: &syn::Generics, l: syn::LifetimeParam) -> syn::Generics {
 }
 
 /// Get the set of lifetimes which need to be constrained to the decoding input lifetime.
-pub fn lifetimes_to_constrain<'a, I>(types: I) -> HashSet<syn::Lifetime>
+pub fn lifetimes_to_constrain<'a, I>(types: I) -> BTreeSet<syn::Lifetime>
 where
-    I: Iterator<Item = (&'a Idx, &'a syn::Type)>
+    I: Iterator<Item = (&'a Idx, Option<&'a BTreeSet<syn::Lifetime>>, &'a syn::Type)>
 {
     // Get the lifetime of a reference if its type matches the predicate.
     fn tyref_lifetime(ty: &syn::Type, pred: impl FnOnce(&syn::Type) -> bool) -> Option<syn::Lifetime> {
@@ -31,22 +32,24 @@ where
     }
 
     // Get all lifetimes of a type.
-    fn get_lifetimes(ty: &syn::Type, set: &mut HashSet<syn::Lifetime>) {
+    fn get_lifetimes(ty: &syn::Type, set: &mut BTreeSet<syn::Lifetime>, filter: &BTreeSet<syn::Lifetime>) {
         match ty {
-            syn::Type::Array(t) => get_lifetimes(&t.elem, set),
-            syn::Type::Slice(t) => get_lifetimes(&t.elem, set),
-            syn::Type::Paren(t) => get_lifetimes(&t.elem, set),
-            syn::Type::Group(t) => get_lifetimes(&t.elem, set),
-            syn::Type::Ptr(t)   => get_lifetimes(&t.elem, set),
+            syn::Type::Array(t) => get_lifetimes(&t.elem, set, filter),
+            syn::Type::Slice(t) => get_lifetimes(&t.elem, set, filter),
+            syn::Type::Paren(t) => get_lifetimes(&t.elem, set, filter),
+            syn::Type::Group(t) => get_lifetimes(&t.elem, set, filter),
+            syn::Type::Ptr(t)   => get_lifetimes(&t.elem, set, filter),
             syn::Type::Reference(t) => {
                 if let Some(l) = &t.lifetime {
-                    set.insert(l.clone());
+                    if filter.is_empty() || filter.contains(l) {
+                        set.insert(l.clone());
+                    }
                 }
-                get_lifetimes(&t.elem, set)
+                get_lifetimes(&t.elem, set, filter)
             }
             syn::Type::Tuple(t) => {
                 for t in &t.elems {
-                    get_lifetimes(t, set)
+                    get_lifetimes(t, set, filter)
                 }
             }
             syn::Type::Path(t) => {
@@ -54,10 +57,14 @@ where
                     if let syn::PathArguments::AngleBracketed(b) = &s.arguments {
                         for a in &b.args {
                             match a {
-                                syn::GenericArgument::Type(t)      => get_lifetimes(t, set),
-                                syn::GenericArgument::AssocType(b) => get_lifetimes(&b.ty, set),
-                                syn::GenericArgument::Lifetime(l)  => { set.insert(l.clone()); }
-                                _                                  => {}
+                                syn::GenericArgument::Type(t)      => get_lifetimes(t, set, filter),
+                                syn::GenericArgument::AssocType(b) => get_lifetimes(&b.ty, set, filter),
+                                syn::GenericArgument::Lifetime(l)  => {
+                                    if filter.is_empty() || filter.contains(l) {
+                                        set.insert(l.clone());
+                                    }
+                                }
+                                _ => {}
                             }
                         }
                     }
@@ -87,8 +94,8 @@ where
         None
     }
 
-    let mut set = HashSet::new();
-    for (i, t) in types {
+    let mut set = BTreeSet::new();
+    for (i, l, t) in types {
         if let Some(l) = tyref_lifetime(t, is_str) {
             set.insert(l);
             continue
@@ -105,8 +112,11 @@ where
             set.insert(l);
             continue
         }
+        if let Some(l) = l {
+            get_lifetimes(t, &mut set, l)
+        }
         if i.is_b() {
-            get_lifetimes(t, &mut set)
+            get_lifetimes(t, &mut set, &BTreeSet::new())
         }
     }
     set


### PR DESCRIPTION
Similar to serde's attribute of the same name it can be attached to fields. The existing `#[b(_)]` attribute is mutually exclusive with `#[cbor(borrow)]` and can be thought of as syntactic sugar for writing `#[cbor(n(_), borrow)]`.

Note that `borrow` accepts optional lifetime parameters to restrict the lifetimes that should be constrained.

With this change, newtypes using "transparent" are no longer required to attach an `#[n(_)]` or `#[b(_)]` attribute.

Closes #14.