### PR TITLE
Allow encoding values as CBOR bytes instead of their actual cbor representation.

### DIFF
--- a/minicbor-tests/tests/encoding.rs
+++ b/minicbor-tests/tests/encoding.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "std")]
 
-use minicbor::{Encode, Decode};
+use minicbor::{Encode, Decode, CborLen};
 
 const NULL: u8 = 0xf6;
 
@@ -261,3 +261,25 @@ fn regular_enum() {
     assert!(d.skip().unwrap_err().is_end_of_input())
 }
 
+#[test]
+fn encode_as_cbor_bytes() {
+    #[derive(Debug, Encode, Decode, PartialEq, Eq, CborLen)]
+    #[cbor(map)]
+    struct T {
+        #[n(0)] a: u8,
+        #[n(1)] b: u8,
+    }
+
+    let value = T { a: 1, b: 2 };
+    
+    let mut e = minicbor::Encoder::new(Vec::new());
+    e.bytes_len(value.cbor_len(&mut ()) as u64).unwrap();
+    value.encode(&mut e, &mut ()).unwrap();
+    let bytes = e.into_writer();
+
+    let mut d = minicbor::Decoder::new(&bytes);
+    let bytes = d.bytes().unwrap();
+
+    let out: T = minicbor::decode(bytes).unwrap();
+    assert_eq!(value, out);
+}

--- a/minicbor/src/encode/encoder.rs
+++ b/minicbor/src/encode/encoder.rs
@@ -2,8 +2,6 @@ use crate::{SIGNED, BYTES, TEXT, ARRAY, MAP, TAGGED, SIMPLE};
 use crate::data::{Int, Tag};
 use crate::encode::{Encode, Error, Write};
 
-use super::CborLen;
-
 /// A non-allocating CBOR encoder writing encoded bytes to the given [`Write`] sink.
 #[derive(Debug, Clone)]
 pub struct Encoder<W> { writer: W }

--- a/minicbor/src/encode/encoder.rs
+++ b/minicbor/src/encode/encoder.rs
@@ -41,20 +41,6 @@ impl<W: Write> Encoder<W> {
         Ok(self)
     }
 
-    /// Encode any type that implements [`Encode`] and [`CborLen`] as a byte string where the value
-    /// of the byte string is the CBOR encoding of the value.
-    pub fn encode_as_cbor<T: Encode<()> + CborLen<()>>(&mut self, x: T) -> Result<&mut Self, Error<W::Error>> {
-        self.type_len(BYTES, x.cbor_len(&mut ()) as u64)?.encode(x)?;
-        Ok(self)
-    }
-
-    /// Encode any type that implements [`Encode`] and [`CborLen`] as a byte string where the value
-    /// of the byte string is the CBOR encoding of the value.
-    pub fn encode_as_cbor_with<C, T: Encode<C> + CborLen<C>>(&mut self, x: T, ctx: &mut C) -> Result<&mut Self, Error<W::Error>> {
-        self.type_len(BYTES, x.cbor_len(ctx) as u64)?.encode_with(x, ctx)?;
-        Ok(self)
-    }
-
     /// Encode a `u8` value.
     pub fn u8(&mut self, x: u8) -> Result<&mut Self, Error<W::Error>> {
         if let 0 ..= 0x17 = x {
@@ -259,6 +245,14 @@ impl<W: Write> Encoder<W> {
     /// Use [`Encoder::end`] to terminate.
     pub fn begin_bytes(&mut self) -> Result<&mut Self, Error<W::Error>> {
         self.put(&[0x5f])
+    }
+
+    /// Begin encoding a string of `len` bytes.
+    ///
+    /// In contrast to [`Encoder::bytes`] which also encodes a byte string, this
+    /// method writes only the CBOR item head.
+    pub fn bytes_len(&mut self, len: u64) -> Result<&mut Self, Error<W::Error>> {
+        self.type_len(BYTES, len)
     }
 
     /// Begin encoding a map of unknown size.

--- a/minicbor/src/encode/encoder.rs
+++ b/minicbor/src/encode/encoder.rs
@@ -2,6 +2,8 @@ use crate::{SIGNED, BYTES, TEXT, ARRAY, MAP, TAGGED, SIMPLE};
 use crate::data::{Int, Tag};
 use crate::encode::{Encode, Error, Write};
 
+use super::CborLen;
+
 /// A non-allocating CBOR encoder writing encoded bytes to the given [`Write`] sink.
 #[derive(Debug, Clone)]
 pub struct Encoder<W> { writer: W }
@@ -36,6 +38,20 @@ impl<W: Write> Encoder<W> {
     /// Encode any type that implements [`Encode`].
     pub fn encode_with<C, T: Encode<C>>(&mut self, x: T, ctx: &mut C) -> Result<&mut Self, Error<W::Error>> {
         x.encode(self, ctx)?;
+        Ok(self)
+    }
+
+    /// Encode any type that implements [`Encode`] and [`CborLen`] as a byte string where the value
+    /// of the byte string is the CBOR encoding of the value.
+    pub fn encode_as_cbor<T: Encode<()> + CborLen<()>>(&mut self, x: T) -> Result<&mut Self, Error<W::Error>> {
+        self.type_len(BYTES, x.cbor_len(&mut ()) as u64)?.encode(x)?;
+        Ok(self)
+    }
+
+    /// Encode any type that implements [`Encode`] and [`CborLen`] as a byte string where the value
+    /// of the byte string is the CBOR encoding of the value.
+    pub fn encode_as_cbor_with<C, T: Encode<C> + CborLen<C>>(&mut self, x: T, ctx: &mut C) -> Result<&mut Self, Error<W::Error>> {
+        self.type_len(BYTES, x.cbor_len(ctx) as u64)?.encode_with(x, ctx)?;
         Ok(self)
     }
 


### PR DESCRIPTION
I often need this functionality and I can't seem to do it without allocating using the current version of this software.

The current solution I have is doing this:
```rust
let encoded_val = minicbor::to_vec(my_value)?;
e.bytes(encoded_val)?;
```
But this allocates to a vector first which is redundant.

I only added the methods to do it with values that implement `CborLen` because this can already be done using indefinite length bytestrings like so:
```rust
e.begin_bytes()?;
e.encode(my_val)?;
e.end()?;
```

I am not sure if I should also mirror the methods on the decoder because values encoded like this can already be decoded without needlessly allocating by doing this:
```rust
let bytes = d.bytes()?;
let value: MyType = minicbor::decode(bytes)?;
```