### PR TITLE
Implement usize conversions on 16-bit architectures

### DIFF
--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -273,6 +273,13 @@ impl<'b, C> Decode<'b, C> for usize {
     }
 }
 
+#[cfg(target_pointer_width = "16")]
+impl<'b, C> Decode<'b, C> for isize {
+    fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, Error> {
+        d.i16().map(|n| n as isize)
+    }
+}
+
 #[cfg(target_pointer_width = "32")]
 impl<'b, C> Decode<'b, C> for isize {
     fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, Error> {

--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -359,7 +359,7 @@ decode_nonzero! {
     core::num::NonZeroI64, "unexpected 0 when decoding a `NonZeroI64`"
 }
 
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+#[cfg(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64"))]
 decode_nonzero! {
     core::num::NonZeroUsize,  "unexpected 0 when decoding a `NonZeroUsize`"
     core::num::NonZeroIsize,  "unexpected 0 when decoding a `NonZeroIsize`"

--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -252,6 +252,13 @@ impl<'b, C, T: Decode<'b, C>> Decode<'b, C> for core::num::Wrapping<T> {
     }
 }
 
+#[cfg(target_pointer_width = "16")]
+impl<'b, C> Decode<'b, C> for usize {
+    fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, Error> {
+        d.u16().map(|n| n as usize)
+    }
+}
+
 #[cfg(target_pointer_width = "32")]
 impl<'b, C> Decode<'b, C> for usize {
     fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, Error> {

--- a/minicbor/src/encode.rs
+++ b/minicbor/src/encode.rs
@@ -333,6 +333,20 @@ impl<C, T: CborLen<C>> CborLen<C> for core::num::Wrapping<T> {
     }
 }
 
+#[cfg(target_pointer_width = "16")]
+impl<C> Encode<C> for usize {
+    fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {
+        e.u16(*self as u16)?.ok()
+    }
+}
+
+#[cfg(target_pointer_width = "16")]
+impl<C> CborLen<C> for usize {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        (*self as u16).cbor_len(ctx)
+    }
+}
+
 #[cfg(target_pointer_width = "32")]
 impl<C> Encode<C> for usize {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {

--- a/minicbor/src/encode.rs
+++ b/minicbor/src/encode.rs
@@ -600,7 +600,7 @@ encode_nonzero! {
     core::num::NonZeroI64
 }
 
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+#[cfg(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64"))]
 encode_nonzero! {
     core::num::NonZeroUsize
     core::num::NonZeroIsize

--- a/minicbor/src/encode.rs
+++ b/minicbor/src/encode.rs
@@ -375,6 +375,20 @@ impl<C> CborLen<C> for usize {
     }
 }
 
+#[cfg(target_pointer_width = "16")]
+impl<C> Encode<C> for isize {
+    fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {
+        e.i16(*self as i16)?.ok()
+    }
+}
+
+#[cfg(target_pointer_width = "16")]
+impl<C> CborLen<C> for isize {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        (*self as i16).cbor_len(ctx)
+    }
+}
+
 #[cfg(target_pointer_width = "32")]
 impl<C> Encode<C> for isize {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {


### PR DESCRIPTION
One architecture CBOR can be interesting for is AVR (ATMega/ATTiny), which has 16-bit wide addresses, and thus needs an extra case for usize conversion. This commit adds that case.

It can be build-tested with in the minicbor crate on very recent nightlies with:

```sh
RUSTFLAGS="-Ctarget-cpu=atmega328" cargo +nightly build --target avr-none -Zbuild-std=core
```

Frankly I have no clue whether Rust development will be a thing on AVR, but there's also the 16-bit wide MSP430, and it's a reasonably easy addition, which is why I think this is already a reasonable proposal before there is any full application to build on it. minicbor is a frequent building block in many of my crates; having a version that supports 16-bit will help me explore more of what can work on those chips.

---

PS: Thanks for maintaining minicbor!