### PR TITLE
feat(serde): Option to serialize unit as null

### DIFF
--- a/minicbor-serde/src/ser.rs
+++ b/minicbor-serde/src/ser.rs
@@ -19,7 +19,8 @@ pub fn to_vec<T: Serialize>(val: T) -> Result<Vec<u8>, EncodeError<core::convert
 /// An implementation of [`serde::Serializer`] using a [`minicbor::Encoder`].
 #[derive(Debug, Clone)]
 pub struct Serializer<W> {
-    encoder: Encoder<W>
+    encoder: Encoder<W>,
+    serialize_unit_as_null: bool,
 }
 
 impl<W: Write> Serializer<W> {
@@ -35,6 +36,12 @@ impl<W: Write> Serializer<W> {
         &mut self.encoder
     }
 
+    #[must_use]
+    pub fn with_serialize_unit_as_null(&mut self, enable: bool) -> &mut Self {
+        self.serialize_unit_as_null = enable;
+        self
+    }
+
     pub fn into_encoder(self) -> Encoder<W> {
         self.encoder
     }
@@ -42,7 +49,7 @@ impl<W: Write> Serializer<W> {
 
 impl<W: Write> From<Encoder<W>> for Serializer<W> {
     fn from(e: Encoder<W>) -> Self {
-        Self { encoder: e }
+        Self { encoder: e, serialize_unit_as_null: false }
     }
 }
 
@@ -144,7 +151,11 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        self.encoder.encode(())?;
+        if self.serialize_unit_as_null {
+            self.encoder.null()?;
+        } else {
+            self.encoder.encode(())?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Hi! For a reason that escapes me `serde_json::Value::Null` uses `serlialze_unit` rather than `serliaize_none`, which doesn't matter for `serde_json` because both end up being serialized `null`. This makes using `serde_json::Value` with this library a bit tricky as deserializing it will return an empty array `[]` rather than `null`.

The least invasive way I see for this is to add an option in the `Serializer` to encode unit as null at the cost of an extra branch. I am not sure where to put a test for it though.

Does this sound acceptable?
