### PR TITLE
Add `#[cbor(tagged)]` for enum variants via tags

### DIFF
--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -29,6 +29,7 @@ pub enum Kind {
     Encoding,
     Index,
     IndexOnly,
+    Tagged,
     Transparent,
     TypeParam,
     Nil,
@@ -48,6 +49,7 @@ enum Value {
     Encoding(Encoding, proc_macro2::Span),
     Index(Idx, proc_macro2::Span),
     IndexOnly(proc_macro2::Span),
+    Tagged(proc_macro2::Span),
     Transparent(proc_macro2::Span),
     TypeParam(TypeParams, proc_macro2::Span),
     Nil(syn::ExprPath, proc_macro2::Span),
@@ -110,6 +112,18 @@ impl Attributes {
             }
             if this.contains_key(Kind::Transparent) {
                 return Err(syn::Error::new(*s, "`tag` and `transparent` are mutually exclusive"))
+            }
+            if this.contains_key(Kind::Tagged) {
+                return Err(syn::Error::new(*s, "`tag` and `tagged` are mutually exclusive"))
+            }
+        }
+        
+        if let Some(Value::Tagged(s)) = this.get(Kind::Tagged) {
+            if this.contains_key(Kind::IndexOnly) {
+                return Err(syn::Error::new(*s, "`tagged` and `index_only` are mutually exclusive"))
+            }
+            if this.contains_key(Kind::Flat) {
+                return Err(syn::Error::new(*s, "`tagged` and `flat` are mutually exclusive"))
             }
         }
         if let Some(Value::Skip(s)) = this.get(Kind::Skip) {
@@ -229,6 +243,8 @@ impl Attributes {
                 let n: LitInt = content.parse()?;
                 let i = n.base10_parse()?;
                 attrs.try_insert(Kind::Tag, Value::Tag(i, meta.path.span()))?
+            } else if meta.path.is_ident("tagged") {
+                attrs.try_insert(Kind::Tagged, Value::Tagged(meta.path.span()))?
             } else if meta.path.is_ident("skip") {
                 attrs.try_insert(Kind::Skip, Value::Skip(meta.path.span()))?
             } else if meta.path.is_ident("flat") {
@@ -286,6 +302,10 @@ impl Attributes {
         self.get(Kind::Tag).and_then(|v| v.tag())
     }
 
+    pub fn tagged(&self) -> bool {
+        self.contains_key(Kind::Tagged)
+    }
+
     pub fn skip(&self) -> bool {
         self.contains_key(Kind::Skip)
     }
@@ -319,6 +339,7 @@ impl Attributes {
                 | Kind::Tag
                 => {}
                 | Kind::Borrow
+                | Kind::Tagged
                 | Kind::TypeParam
                 | Kind::Codec
                 | Kind::Index
@@ -347,6 +368,7 @@ impl Attributes {
                 | Kind::Skip
                 => {}
                 | Kind::Encoding
+                | Kind::Tagged
                 | Kind::IndexOnly
                 | Kind::Transparent
                 | Kind::ContextBound
@@ -362,6 +384,7 @@ impl Attributes {
                 | Kind::ContextBound
                 | Kind::Tag
                 | Kind::Flat
+                | Kind::Tagged
                 => {}
                 | Kind::Borrow
                 | Kind::TypeParam
@@ -387,6 +410,7 @@ impl Attributes {
                 | Kind::TypeParam
                 | Kind::Codec
                 | Kind::IndexOnly
+                | Kind::Tagged
                 | Kind::Transparent
                 | Kind::Nil
                 | Kind::IsNil
@@ -559,6 +583,7 @@ impl Value {
             Value::Encoding(_, s)     => *s,
             Value::Index(_, s)        => *s,
             Value::IndexOnly(s)       => *s,
+            Value::Tagged(s)          => *s,
             Value::Transparent(s)     => *s,
             Value::Nil(_, s)          => *s,
             Value::IsNil(_, s)        => *s,

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -136,8 +136,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let mut lifetime = gen_lifetime()?;
     let mut rows = Vec::new();
     
-    // Base tag for tagged enums (CBOR tag 121)
-    const BASE_TAG: u64 = 121;
 
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
         let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
@@ -237,12 +235,13 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             let __tag777 = __d777.tag()?;
             let __tag_val777 = __tag777.as_u64();
             
-            if __tag_val777 < #BASE_TAG {
-                return Err(minicbor::decode::Error::message("invalid tag value for tagged enum").at(__p777))
-            }
+            let __tag_val_offset777 = match __tag_val777 {
+                121..127 => Ok(121),
+                1280..1400 => Ok(1280 - 7),
+                _ => Err(minicbor::decode::Error::message("invalid tag value for tagged enum").at(__p777))
+            }?;
             
-            // The index to match against is the tag value minus the base tag
-            let __idx777 = (__tag_val777 - #BASE_TAG) as i64;
+            let __idx777 = (__tag_val777 - __tag_val_offset777) as i64;
             let __p778 = __p777;
         }
     } else {

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -127,6 +127,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let enum_attrs    = Attributes::try_from_iter(Level::Enum, inp.attrs.iter())?;
     let enum_encoding = enum_attrs.encoding().unwrap_or_default();
     let index_only    = enum_attrs.index_only();
+    let tagged        = enum_attrs.tagged();
     let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter(), &enum_attrs)?;
 
@@ -134,6 +135,10 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let mut field_attrs = Vec::new();
     let mut lifetime = gen_lifetime()?;
     let mut rows = Vec::new();
+    
+    // Base tag for tagged enums (CBOR tag 121)
+    const BASE_TAG: u64 = 121;
+
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
         let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
@@ -226,6 +231,20 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             }
             let __p778 = __d777.position();
         }
+    } else if tagged {
+        quote! {
+            let __p777 = __d777.position();
+            let __tag777 = __d777.tag()?;
+            let __tag_val777 = __tag777.as_u64();
+            
+            if __tag_val777 < #BASE_TAG {
+                return Err(minicbor::decode::Error::message("invalid tag value for tagged enum").at(__p777))
+            }
+            
+            // The index to match against is the tag value minus the base tag
+            let __idx777 = (__tag_val777 - #BASE_TAG) as i64;
+            let __p778 = __p777;
+        }
     } else {
         quote! {
             let __p777 = __d777.position();
@@ -238,12 +257,19 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 
     let tag = decode_tag(&enum_attrs);
 
+    let match_expr = if tagged {
+        quote!(__idx777 as i64)
+    } else {
+        quote!(__d777.i64()?)
+    };
+
     Ok(quote! {
         impl #impl_generics minicbor::Decode<'bytes, Ctx> for #name #typ_generics #where_clause {
             fn decode(__d777: &mut minicbor::Decoder<'bytes>, __ctx777: &mut Ctx) -> core::result::Result<#name #typ_generics, minicbor::decode::Error> {
                 #tag
                 #check
-                match __d777.i64()? {
+                
+                match #match_expr {
                     #(#rows)*
                     n => Err(minicbor::decode::Error::unknown_variant(n).at(__p778))
                 }

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -93,12 +93,16 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let enum_attrs    = Attributes::try_from_iter(Level::Enum, inp.attrs.iter())?;
     let enum_encoding = enum_attrs.encoding().unwrap_or_default();
     let index_only    = enum_attrs.index_only();
+    let tagged        = enum_attrs.tagged();
     let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter(), &enum_attrs)?;
 
     let mut blacklist = HashSet::new();
     let mut field_attrs = Vec::new();
     let mut rows = Vec::new();
+    
+    // Base tag for tagged enums (CBOR tag 121)
+    const BASE_TAG: u64 = 121;
 
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
         let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
@@ -110,6 +114,9 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         let con = &var.ident;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let tag = encode_tag(attrs);
+        
+        let variant_tag = BASE_TAG + idx.val() as u64;
+        
         let row = match &var.fields {
             syn::Fields::Unit => match encoding {
                 Encoding::Array | Encoding::Map if index_only => quote! {
@@ -125,12 +132,26 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                         Ok(())
                     }
                 },
+                Encoding::Array if tagged => quote! {
+                    #name::#con => {
+                        __e777.tag(minicbor::data::Tag::new(#variant_tag))?;
+                        __e777.array(0)?;
+                        Ok(())
+                    }
+                },
                 Encoding::Array => quote! {
                     #name::#con => {
                         __e777.array(2)?;
                         __e777.i64(#idx)?;
                         #tag
                         __e777.array(0)?;
+                        Ok(())
+                    }
+                },
+                Encoding::Map if tagged => quote! {
+                    #name::#con => {
+                        __e777.tag(minicbor::data::Tag::new(#variant_tag))?;
+                        __e777.map(0)?;
                         Ok(())
                     }
                 },
@@ -163,6 +184,17 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     }
                 }
             }
+            syn::Fields::Named(_) if tagged => {
+                let (tests, statements) = encode_fields(&fields, false, encoding, false)?;
+                let idents = fields.fields().idents();
+                quote! {
+                    #name::#con{#(#idents,)* ..} => {
+                        #tests
+                        __e777.tag(minicbor::data::Tag::new(#variant_tag))?;
+                        #statements
+                    }
+                }
+            }
             syn::Fields::Named(_) => {
                 let (tests, statements) = encode_fields(&fields, false, encoding, false)?;
                 let idents = fields.fields().idents();
@@ -191,6 +223,17 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                             __e777.array(1)?;
                         }
                         __e777.i64(#idx)?;
+                        #statements
+                    }
+                }
+            }
+            syn::Fields::Unnamed(_) if tagged => {
+                let (tests, statements) = encode_fields(&fields, false, encoding, false)?;
+                let idents = fields.match_idents();
+                quote! {
+                    #name::#con(#(#idents,)*) => {
+                        #tests
+                        __e777.tag(minicbor::data::Tag::new(#variant_tag))?;
                         #statements
                     }
                 }

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -100,9 +100,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let mut blacklist = HashSet::new();
     let mut field_attrs = Vec::new();
     let mut rows = Vec::new();
-    
-    // Base tag for tagged enums (CBOR tag 121)
-    const BASE_TAG: u64 = 121;
 
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
         let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
@@ -115,7 +112,14 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let tag = encode_tag(attrs);
         
-        let variant_tag = BASE_TAG + idx.val() as u64;
+        let variant_tag = match idx.val() as u64 {
+            0..=6 => Ok(121 + idx.val() as u64),
+            7..=127 => Ok(1280 + idx.val() as u64 - 7),
+            _ => Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "enums with more than 128 variants are currently not supported with tagged encoding",
+            )),
+        }?;
         
         let row = match &var.fields {
             syn::Fields::Unit => match encoding {

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -92,6 +92,7 @@
 //! - [`#[cbor(array)]`](#cborarray)
 //! - [`#[cbor(map)]`](#cbormap)
 //! - [`#[cbor(index_only)]`](#cborindex_only)
+//! - [`#[cbor(tagged)]`](#cbortagged)
 //! - [`#[cbor(transparent)]`](#cbortransparent)
 //! - [`#[cbor(skip)]`](#cborskip)
 //! - [`#[cbor(tag(...))]`](#cbortag)
@@ -153,6 +154,14 @@
 //! Enumerations which do not contain fields may have this attribute attached to
 //! them. This changes the encoding to encode only the variant index (cf. section
 //! [CBOR encoding](#cbor-encoding) for details).
+//!
+//! ## `#[cbor(tagged)]`
+//!
+//! This attribute can be attached to enums. It provides a "tagged" encoding,
+//! such that the first 7 variants are stored using tags 120..127, the next
+//! 121 variants are stored using tags 1280..1400. The spec supports more than
+//! 128 variants via tag 101 with an array like [uint, any], but this is currently
+//! not supported.
 //!
 //! ## `#[cbor(flat)]`
 //!

--- a/minicbor-tests/tests/encoding.rs
+++ b/minicbor-tests/tests/encoding.rs
@@ -354,10 +354,11 @@ fn tagged_enum() {
         #[n(0)] A,
         #[n(1)] B,
         #[n(2)] C(#[n(0)] u8, #[n(1)] String),
-        #[cbor(map)] #[n(3)] D {
+        #[cbor(map)] #[n(3)] F {
             #[n(0)] x: bool,
             #[n(1)] y: String
-        }
+        },
+        #[n(7)] G,
     }
 
     // Test unit variant - should be encoded with tag 121 (BASE_TAG + 0)
@@ -381,18 +382,24 @@ fn tagged_enum() {
     
     assert_eq!(c, minicbor::decode(&bytes).unwrap());
     
-    let d = E::D { x: true, y: "test".to_string() };
-    let bytes = minicbor::to_vec(&d).unwrap();
-    let mut decoder = minicbor::Decoder::new(&bytes);
+    let f = E::F { x: true, y: "test".to_string() };
+    let bytes = minicbor::to_vec(&f).unwrap();
+    let mut d = minicbor::Decoder::new(&bytes);
     
-    assert_eq!(minicbor::data::Tag::new(124), decoder.tag().unwrap());
-    assert_eq!(Some(2), decoder.map().unwrap());
-    assert_eq!(0, decoder.i64().unwrap());
-    assert_eq!(true, decoder.bool().unwrap());
-    assert_eq!(1, decoder.i64().unwrap());
-    assert_eq!("test", decoder.str().unwrap());
+    assert_eq!(minicbor::data::Tag::new(124), d.tag().unwrap());
+    assert_eq!(Some(2), d.map().unwrap());
+    assert_eq!(0, d.i64().unwrap());
+    assert_eq!(true, d.bool().unwrap());
+    assert_eq!(1, d.i64().unwrap());
+    assert_eq!("test", d.str().unwrap());
     
-    assert_eq!(d, minicbor::decode(&bytes).unwrap());
+    assert_eq!(f, minicbor::decode(&bytes).unwrap());
+
+    let g = E::G;
+    let bytes = minicbor::to_vec(&g).unwrap();
+    // d9 = tag, 05 + 00 = 1280, 80 = empty array
+    assert_eq!(&[0xd9, 0x05, 0x00, 0x80][..], &bytes[..]);
+    assert_eq!(E::G, minicbor::decode(&bytes).unwrap());
     
     let mut e = minicbor::Encoder::new(Vec::new());
     e.array(4).unwrap()

--- a/minicbor-tests/tests/encoding.rs
+++ b/minicbor-tests/tests/encoding.rs
@@ -345,3 +345,66 @@ fn encode_as_cbor_bytes() {
     let out: T = minicbor::decode(bytes).unwrap();
     assert_eq!(value, out);
 }
+
+#[test]
+fn tagged_enum() {
+    #[derive(Debug, Encode, Decode, PartialEq, Eq)]
+    #[cbor(tagged)]
+    enum E {
+        #[n(0)] A,
+        #[n(1)] B,
+        #[n(2)] C(#[n(0)] u8, #[n(1)] String),
+        #[cbor(map)] #[n(3)] D {
+            #[n(0)] x: bool,
+            #[n(1)] y: String
+        }
+    }
+
+    // Test unit variant - should be encoded with tag 121 (BASE_TAG + 0)
+    let bytes = minicbor::to_vec(&E::A).unwrap();
+    // d8 = tag, 79 = 121, 80 = empty array
+    assert_eq!(&[0xd8, 0x79, 0x80][..], &bytes[..]);
+    assert_eq!(E::A, minicbor::decode(&bytes).unwrap());
+    
+    let bytes = minicbor::to_vec(&E::B).unwrap();
+    assert_eq!(&[0xd8, 0x7a, 0x80][..], &bytes[..]);
+    assert_eq!(E::B, minicbor::decode(&bytes).unwrap());
+    
+    let c = E::C(42, "hello".to_string());
+    let bytes = minicbor::to_vec(&c).unwrap();
+    let mut d = minicbor::Decoder::new(&bytes);
+    
+    assert_eq!(minicbor::data::Tag::new(123), d.tag().unwrap());
+    assert_eq!(Some(2), d.array().unwrap());
+    assert_eq!(42u8, d.u8().unwrap());
+    assert_eq!("hello", d.str().unwrap());
+    
+    assert_eq!(c, minicbor::decode(&bytes).unwrap());
+    
+    let d = E::D { x: true, y: "test".to_string() };
+    let bytes = minicbor::to_vec(&d).unwrap();
+    let mut decoder = minicbor::Decoder::new(&bytes);
+    
+    assert_eq!(minicbor::data::Tag::new(124), decoder.tag().unwrap());
+    assert_eq!(Some(2), decoder.map().unwrap());
+    assert_eq!(0, decoder.i64().unwrap());
+    assert_eq!(true, decoder.bool().unwrap());
+    assert_eq!(1, decoder.i64().unwrap());
+    assert_eq!("test", decoder.str().unwrap());
+    
+    assert_eq!(d, minicbor::decode(&bytes).unwrap());
+    
+    let mut e = minicbor::Encoder::new(Vec::new());
+    e.array(4).unwrap()
+        .encode(&E::A).unwrap()
+        .encode(&E::B).unwrap()
+        .encode(32u8).unwrap()
+        .encode("foo").unwrap();
+    
+    let mut d = minicbor::Decoder::new(e.writer());
+    assert_eq!(Some(4), d.array().unwrap());
+    assert_eq!(E::A, d.decode().unwrap());
+    assert_eq!(E::B, d.decode().unwrap());
+    assert_eq!(32u8, d.decode().unwrap());
+    assert_eq!("foo", d.str().unwrap());
+}


### PR DESCRIPTION
Hey there, thanks for the library! I've added a new `cbor(tagged)` for enums where the variant is picked based on the tag. Tags 121..127 for the first 7 variants and 1280..1400 for the next 121 variants. https://www.ietf.org/archive/id/draft-bormann-cbor-notable-tags-07.html#name-enumerated-alternative-data