### PR TITLE
Add `#[cbor(array(indefinite))]` for indefinite arrays

### DIFF
--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -155,7 +155,18 @@ impl Attributes {
             } else if meta.path.is_ident("map") {
                 attrs.try_insert(Kind::Encoding, Value::Encoding(Encoding::Map, meta.path.span()))?
             } else if meta.path.is_ident("array") {
-                attrs.try_insert(Kind::Encoding, Value::Encoding(Encoding::Array, meta.path.span()))?
+                if meta.input.peek(syn::token::Paren) {
+                    let content;
+                    syn::parenthesized!(content in meta.input);
+                    let s = content.parse::<syn::Ident>()?;
+                    match s.to_string().as_str() {
+                        "indefinite" => attrs.try_insert(Kind::Encoding, Value::Encoding(Encoding::IndefiniteArray, meta.path.span()))?,
+                        "definite" => attrs.try_insert(Kind::Encoding, Value::Encoding(Encoding::Array, meta.path.span()))?,
+                        _ => return Err(meta.error("expected `array(indefinite)`, `array(definite)` or `array` (equivalent to `array(definite)`)"))
+                    }
+                } else {
+                    attrs.try_insert(Kind::Encoding, Value::Encoding(Encoding::Array, meta.path.span()))?;
+                }
             } else if meta.path.is_ident("has_nil") {
                 attrs.try_insert(Kind::HasNil, Value::HasNil(meta.path.span()))?
             } else if meta.path.is_ident("encode_with") {

--- a/minicbor-derive/src/attrs/encoding.rs
+++ b/minicbor-derive/src/attrs/encoding.rs
@@ -3,12 +3,13 @@
 pub enum Encoding {
     #[default]
     Array,
+    IndefiniteArray,
     Map
 }
 
 impl Encoding {
     pub fn is_array(self) -> bool {
-        matches!(self, Self::Array)
+        matches!(self, Self::Array | Self::IndefiniteArray)
     }
 
     pub fn is_map(self) -> bool {

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -111,10 +111,10 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     Encoding::Map => quote! {
                         #name::#con{#(#idents,)* ..} => { 1 + #idx.cbor_len(__ctx777) + #tag + #(#steps)* }
                     },
-                    Encoding::Array if flat => quote! {
+                    Encoding::Array | Encoding::IndefiniteArray if flat => quote! {
                         #name::#con{#(#idents,)* ..} => { #(#steps)* + #idx.cbor_len(__ctx777) }
                     },
-                    Encoding::Array => quote! {
+                    Encoding::Array | Encoding::IndefiniteArray => quote! {
                         #name::#con{#(#idents,)* ..} => { #(#steps)* + #tag + 1 + #idx.cbor_len(__ctx777) }
                     }
                 }
@@ -129,10 +129,10 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     Encoding::Map => quote! {
                         #name::#con(#(#idents,)*) => { 1 + #idx.cbor_len(__ctx777) + #tag + #(#steps)* }
                     },
-                    Encoding::Array if flat => quote! {
+                    Encoding::Array | Encoding::IndefiniteArray if flat => quote! {
                         #name::#con(#(#idents,)*) => { #(#steps)* + #idx.cbor_len(__ctx777) }
                     },
-                    Encoding::Array => quote! {
+                    Encoding::Array | Encoding::IndefiniteArray => quote! {
                         #name::#con(#(#idents,)*) => { #(#steps)* + #tag + 1 + #idx.cbor_len(__ctx777) }
                     }
                 }
@@ -223,7 +223,7 @@ fn on_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Result
             }
             steps
         }
-        Encoding::Array => {
+        Encoding::Array | Encoding::IndefiniteArray => {
             let mut steps = Vec::new();
             steps.push(quote! {
                 let mut __num777 = 0;

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -347,7 +347,7 @@ fn gen_statements(fields: &Fields, encoding: Encoding, flat: bool) -> syn::Resul
     let indices = fields.fields().indices().collect::<Vec<_>>();
 
     Ok(match encoding {
-        Encoding::Array if flat => quote! {
+        Encoding::Array | Encoding::IndefiniteArray if flat => quote! {
             #(let mut #idents : core::option::Option<#types> = #inits;)*
 
             for __i777 in 0 .. __len777 - 1 {
@@ -357,7 +357,7 @@ fn gen_statements(fields: &Fields, encoding: Encoding, flat: bool) -> syn::Resul
                 }
             }
         },
-        Encoding::Array => quote! {
+        Encoding::Array | Encoding::IndefiniteArray => quote! {
             #(let mut #idents : core::option::Option<#types> = #inits;)*
 
             if let Some(__len777) = __d777.array()? {

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -112,20 +112,20 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         let tag = encode_tag(attrs);
         let row = match &var.fields {
             syn::Fields::Unit => match encoding {
-                Encoding::Array | Encoding::Map if index_only => quote! {
+                Encoding::Array | Encoding::IndefiniteArray | Encoding::Map if index_only => quote! {
                     #name::#con => {
                         __e777.i64(#idx)?;
                         Ok(())
                     }
                 },
-                Encoding::Array if flat => quote! {
+                Encoding::Array | Encoding::IndefiniteArray if flat => quote! {
                     #name::#con => {
                         __e777.array(1)?;
                         __e777.i64(#idx)?;
                         Ok(())
                     }
                 },
-                Encoding::Array => quote! {
+                Encoding::Array | Encoding::IndefiniteArray => quote! {
                     #name::#con => {
                         __e777.array(2)?;
                         __e777.i64(#idx)?;
@@ -273,7 +273,7 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding, flat: bool
         // Under array encoding the number of elements is the highest
         // index + 1. Each value is checked if it is not nil and if so,
         // the highest index is incremented.
-        Encoding::Array => {
+        Encoding::Array | Encoding::IndefiniteArray => {
             for field in fields.fields() {
                 if field.attrs.skip() {
                     continue
@@ -413,7 +413,7 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding, flat: bool
         // Under array encoding only field values are encoded and their
         // index is represented as the array position. Gaps between indexes
         // need to be filled with null.
-        Encoding::Array => {
+        Encoding::Array | Encoding::IndefiniteArray => {
             let mut first = true;
             let mut k = 0;
             for field in fields.fields() {
@@ -519,7 +519,7 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding, flat: bool
         })?;
 
     match encoding {
-        Encoding::Array if flat => Ok((
+        Encoding::Array | Encoding::IndefiniteArray if flat => Ok((
             quote! {
                 let mut __max_index777: core::option::Option<u64> = None;
 
@@ -546,6 +546,22 @@ fn encode_fields(fields: &Fields, has_self: bool, encoding: Encoding, flat: bool
                 } else {
                     __e777.array(0)?;
                 }
+
+                Ok(())
+            }
+        )),
+        Encoding::IndefiniteArray => Ok((
+            quote! {
+                let mut __max_index777: core::option::Option<u64> = None;
+
+                #(#tests)*
+            },
+            quote! {
+                __e777.begin_array()?;
+                if let Some(__i777) = __max_index777 {
+                    #(#statements)*
+                }
+                __e777.end()?;
 
                 Ok(())
             }

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -139,6 +139,13 @@
 //! If neither `#[cbor(array)]` nor `#[cbor(map)]` are specified, `#[cbor(array)]`
 //! is used by default.
 //!
+//! ## `#[cbor(array(indefinite))]`
+//!
+//! Similar to `#[cbor(array)]` but encodes the array as an indefinite number of
+//! CBOR items. This has no effect on decoding as oth `#[cbor(array)]` and
+//! `#[cbor(array(indefinite))]` are able to decode definite and indefinite length
+//! arrays.
+//!
 //! ## `#[cbor(map)]`
 //!
 //! Use a CBOR map to encode the annotated struct, enum or enum variant.

--- a/minicbor-tests/tests/encoding.rs
+++ b/minicbor-tests/tests/encoding.rs
@@ -58,6 +58,59 @@ fn encode_as_array() {
 }
 
 #[test]
+fn encode_as_array_indefinite() {
+    #[derive(Debug, Encode, Decode, PartialEq, Eq)]
+    #[cbor(array(indefinite))]
+    struct T {
+        #[n(0)] a: Option<u8>,
+        #[n(2)] b: Option<u8>,
+        #[n(5)] c: Option<u8>
+    }
+
+    // empty value => empty array
+    let v = T { a: None, b: None, c: None };
+
+    let bytes = minicbor::to_vec(&v).unwrap();
+    assert_eq!(&[0x9f, 0xff][..], &bytes[..]);
+    assert_eq!(v, minicbor::decode(&bytes).unwrap());
+
+    // empty suffix is not encoded
+    let v = T { a: Some(1), b: None, c: None };
+
+    let bytes = minicbor::to_vec(&v).unwrap();
+    assert_eq!(&[0x9f, 1, 0xff][..], &bytes[..]);
+    assert_eq!(v, minicbor::decode(&bytes).unwrap());
+
+    // gaps are filled with nulls
+    let v = T { a: Some(1), b: Some(2), c: None };
+
+    let bytes = minicbor::to_vec(&v).unwrap();
+    assert_eq!(&[0x9f, 1, NULL, 2, 0xff][..], &bytes[..]);
+    assert_eq!(v, minicbor::decode(&bytes).unwrap());
+
+    // more gaps to fill
+    let v = T { a: Some(1), b: Some(2), c: Some(3) };
+
+    let bytes = minicbor::to_vec(&v).unwrap();
+    assert_eq!(&[0x9f, 1, NULL, 2, NULL, NULL, 3, 0xff][..], &bytes[..]);
+    assert_eq!(v, minicbor::decode(&bytes).unwrap());
+
+    // and even more
+    let v = T { a: Some(1), b: None, c: Some(3) };
+
+    let bytes = minicbor::to_vec(&v).unwrap();
+    assert_eq!(&[0x9f, 1, NULL, NULL, NULL, NULL, 3, 0xff][..], &bytes[..]);
+    assert_eq!(v, minicbor::decode(&bytes).unwrap());
+
+    // empty prefix is filled with nulls too
+    let v = T { a: None, b: None, c: Some(3) };
+
+    let bytes = minicbor::to_vec(&v).unwrap();
+    assert_eq!(&[0x9f, NULL, NULL, NULL, NULL, NULL, 3, 0xff][..], &bytes[..]);
+    assert_eq!(v, minicbor::decode(&bytes).unwrap())
+}
+
+#[test]
 fn encode_as_map() {
     #[derive(Debug, Encode, Decode, PartialEq, Eq)]
     #[cbor(map)]


### PR DESCRIPTION
Adds support for unbounded arrays via `#[cbor(array(indefinite))]` and the relevant documentation. This can be useful when working with other systems that expect indefinite arrays. This has no effect on decoding since minicbor already supports definite and indefinite arrays when decoding.

I'm not certain the `syn` code for parsing `#[cbor(array)]` vs `#[cbor(array(indefinite))]` is ideal. But overall, if you like the approach, I'd be happy to support indefinite maps in a separate PR!

Closes #17