### PR TITLE
fix: Type annotations needed error.

### DIFF
--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -311,8 +311,12 @@ fn gen_statements(fields: &Fields, encoding: Encoding, flat: bool) -> syn::Resul
         let unknown_var_err =
             if let Some(cd) = field.attrs.codec() {
                 if let Some(p) = cd.to_nil_path() {
+                    let field_type = &field.typ;
                     quote! {
-                        Err(e) if e.is_unknown_variant() && #p().is_some() => {
+                        Err(e) if e.is_unknown_variant() && {
+                            let maybe_nil: Option<#field_type> = #p();
+                            maybe_nil.is_some()
+                        } => {
                             __d777.skip()?
                         }
                     }


### PR DESCRIPTION
Here is a minimal reproduction for the bug:

```rust
use minicbor::{Decoder, decode as de, Decode};

pub fn my_decode<'a, C, T>(
    d: &mut Decoder<'a>,
    ctx: &mut C,
) -> Result<Box<[T]>, de::Error>
    where
        T: de::Decode<'a, C>,
{
    let v: Vec<T> = d.decode_with(ctx)?;
    Ok(v.into_boxed_slice())
}

pub fn my_nil<T>() -> Option<Box<[T]>> {
    Some(Vec::new().into_boxed_slice())
}

#[derive(Decode)]
struct CompileError {
    #[n(0)]
    #[cbor(decode_with = "my_decode", nil = "my_nil")]
    here: Box<[u64]>,
}
```

Basically if the custom `nil` implementation uses generics then it trips up type checking in the generated `Decode` implementation.

This simply adds an intermediate variable so we can bound the nil function to the field type. I'm not very experienced with proc-macro development so make sure that this is correct.