### PR TITLE
Fix type parameter bounds.

### DIFF
--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -31,7 +31,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     let name      = &inp.ident;
     let attrs     = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
     let fields    = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
-    let blacklist = fields.gen_blacklist(&inp.generics, None);
+    let blacklist = fields.blacklist(&inp.generics, None);
 
     let cbor_len_bound = gen_cbor_len_bound()?;
     let encode_bound   = gen_encode_bound()?;

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -1,7 +1,9 @@
-use crate::{attrs::{Attributes, Level, Encoding, CustomCodec}, fields::Fields, add_typeparam, gen_ctx_param, variants::Variants, encode::is_nil};
 use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
-use crate::fields::Field;
+
+use crate::{add_typeparam, encode::is_nil, fields::Fields, gen_ctx_param, variants::Variants};
+use crate::attrs::{Attributes, CustomCodec, Encoding, Level};
+use crate::fields::{Blacklist, Field};
 
 /// Entry point to derive `minicbor::CborLen` on structs and enums.
 pub fn derive_from(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -26,15 +28,18 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             unreachable!("`derive_from` matched against `syn::Data::Struct`")
         };
 
-    let name   = &inp.ident;
-    let attrs  = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
-    let fields = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
+    let name      = &inp.ident;
+    let attrs     = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
+    let fields    = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
+    let blacklist = fields.gen_blacklist(&inp.generics, None);
 
     let cbor_len_bound = gen_cbor_len_bound()?;
     let encode_bound   = gen_encode_bound()?;
     for p in inp.generics.type_params_mut() {
-        p.bounds.push(cbor_len_bound.clone());
-        p.bounds.push(encode_bound.clone())
+        if !blacklist.contains(p) {
+            p.bounds.push(cbor_len_bound.clone());
+            p.bounds.push(encode_bound.clone())
+        }
     }
 
     let generics = add_typeparam(&inp.generics, gen_ctx_param()?, attrs.context_bound());
@@ -81,9 +86,11 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter(), &enum_attrs)?;
 
+    let mut blacklist = Blacklist::default();
     let mut rows = Vec::new();
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
-        let fields   = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
+        let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
+        blacklist.merge(&inp.generics, None, &fields);
         let con      = &var.ident;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let tag      = on_tag(attrs);
@@ -144,8 +151,10 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let cbor_len_bound = gen_cbor_len_bound()?;
     let encode_bound   = gen_encode_bound()?;
     for p in inp.generics.type_params_mut() {
-        p.bounds.push(cbor_len_bound.clone());
-        p.bounds.push(encode_bound.clone())
+        if !blacklist.contains(p) {
+            p.bounds.push(cbor_len_bound.clone());
+            p.bounds.push(encode_bound.clone())
+        }
     }
     let generics = add_typeparam(&inp.generics, gen_ctx_param()?, enum_attrs.context_bound());
     let impl_generics = generics.split_for_impl().0;
@@ -331,4 +340,3 @@ fn on_tag(a: &Attributes) -> proc_macro2::TokenStream {
         quote!(0)
     }
 }
-

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -36,7 +36,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     let cbor_len_bound = gen_cbor_len_bound()?;
     let encode_bound   = gen_encode_bound()?;
     for p in inp.generics.type_params_mut() {
-        if !blacklist.contains(p) {
+        if !blacklist.contains(&p.ident) {
             p.bounds.push(cbor_len_bound.clone());
             p.bounds.push(encode_bound.clone())
         }
@@ -151,7 +151,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let cbor_len_bound = gen_cbor_len_bound()?;
     let encode_bound   = gen_encode_bound()?;
     for p in inp.generics.type_params_mut() {
-        if !blacklist.contains(p) {
+        if !blacklist.contains(&p.ident) {
             p.bounds.push(cbor_len_bound.clone());
             p.bounds.push(encode_bound.clone())
         }

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -36,7 +36,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     let name      = &inp.ident;
     let attrs     = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
     let fields    = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
-    let blacklist = fields.gen_blacklist(&inp.generics, Mode::Decode);
+    let blacklist = fields.blacklist(&inp.generics, Mode::Decode);
 
     let mut lifetime = gen_lifetime()?;
     for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, f.attrs.borrow(), &f.typ))) {

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -51,7 +51,6 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             (f.attrs.default() || f.attrs.skip()) && !is_phantom_data(&f.typ)
         }))
         .into_iter()
-        .map(|t| t.ident)
         .collect();
 
     let bound  = gen_decode_bound()?;
@@ -173,7 +172,6 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     (f.attrs.default() || f.attrs.skip()) && !is_phantom_data(&f.typ)
                 }))
                 .into_iter()
-                .map(|t| t.ident)
             );
             let statements = gen_statements(&fields, encoding, flat)?;
             if let syn::Fields::Named(_) = var.fields {

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -1,13 +1,14 @@
-use crate::Mode;
-use crate::{add_bound_to_type_params, collect_type_params, is_cow, is_option, is_str, is_byte_slice};
-use crate::{add_typeparam, gen_ctx_param, add_bound_to_matching_type_params};
-use crate::attrs::{Attributes, CustomCodec, Encoding, Level};
-use crate::fields::{Field, Fields};
-use crate::variants::Variants;
-use crate::lifetimes::{gen_lifetime, lifetimes_to_constrain, add_lifetime};
 use quote::quote;
 use std::collections::HashSet;
 use syn::spanned::Spanned;
+
+use crate::{is_phantom_data, Mode};
+use crate::{add_bound_to_type_params, collect_type_params, is_cow, is_option, is_str, is_byte_slice};
+use crate::{add_typeparam, gen_ctx_param, add_bound_to_matching_type_params};
+use crate::attrs::{Attributes, CustomCodec, Encoding, Level};
+use crate::fields::{Blacklist, Field, Fields};
+use crate::variants::Variants;
+use crate::lifetimes::{gen_lifetime, lifetimes_to_constrain, add_lifetime};
 
 /// Entry point to derive `minicbor::Decode` on structs and enums.
 pub fn derive_from(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -32,9 +33,10 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             unreachable!("`derive_from` matched against `syn::Data::Struct`")
         };
 
-    let name   = &inp.ident;
-    let attrs  = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
-    let fields = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
+    let name      = &inp.ident;
+    let attrs     = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
+    let fields    = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
+    let blacklist = fields.gen_blacklist(&inp.generics, Mode::Decode);
 
     let mut lifetime = gen_lifetime()?;
     for l in lifetimes_to_constrain(fields.fields().map(|f| (&f.index, f.attrs.borrow(), &f.typ))) {
@@ -43,16 +45,10 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
         }
     }
 
-    // Collect type parameters which should not have a `Decode` bound added,
-    // i.e. from fields which have a custom decode function defined.
-    let blacklist = collect_type_params(&inp.generics, fields.fields().filter(|f| {
-        f.attrs.codec().map(|c| c.is_decode()).unwrap_or(false)
-    }));
-
     // Collect type parameters which require a `Default` bound.
     let default_types =
         collect_type_params(&inp.generics, fields.fields().chain(fields.skipped()).filter(|f| {
-            f.attrs.default() || f.attrs.skip()
+            (f.attrs.default() || f.attrs.skip()) && !is_phantom_data(&f.typ)
         }))
         .into_iter()
         .map(|t| t.ident)
@@ -144,7 +140,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter(), &enum_attrs)?;
 
-    let mut blacklist = HashSet::new();
+    let mut blacklist = Blacklist::default();
     let mut defaults = HashSet::new();
     let mut field_attrs = Vec::new();
     let mut lifetime = gen_lifetime()?;
@@ -170,17 +166,11 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                     lifetime.bounds.push(l.clone())
                 }
             }
-            // Collect type parameters which should not have an `Decode` bound added,
-            // i.e. from fields which have a custom decode function defined.
-            blacklist.extend(
-                collect_type_params(&inp.generics, fields.fields().filter(|f| {
-                    f.attrs.codec().map(|c| c.is_decode()).unwrap_or(false)
-                }))
-            );
+            blacklist.merge(&inp.generics, Mode::Decode, &fields);
             // Collect type parameters which require a `Default` bound.
             defaults.extend(
                 collect_type_params(&inp.generics, fields.fields().chain(fields.skipped()).filter(|f| {
-                    f.attrs.default() || f.attrs.skip()
+                    (f.attrs.default() || f.attrs.skip()) && !is_phantom_data(&f.typ)
                 }))
                 .into_iter()
                 .map(|t| t.ident)

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -35,7 +35,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     let attrs     = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
     let encoding  = attrs.encoding().unwrap_or_default();
     let fields    = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
-    let blacklist = fields.gen_blacklist(&inp.generics, Mode::Encode);
+    let blacklist = fields.blacklist(&inp.generics, Mode::Encode);
 
     {
         let bound  = gen_encode_bound()?;

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -1,12 +1,12 @@
+use quote::{quote, ToTokens};
+use syn::spanned::Spanned;
+
 use crate::Mode;
-use crate::{add_bound_to_type_params, collect_type_params, is_option};
+use crate::{add_bound_to_type_params, is_option};
 use crate::{add_typeparam, gen_ctx_param};
 use crate::attrs::{Attributes, CustomCodec, Encoding, Level};
-use crate::fields::{Field, Fields};
+use crate::fields::{Blacklist, Field, Fields};
 use crate::variants::Variants;
-use quote::{quote, ToTokens};
-use std::collections::HashSet;
-use syn::spanned::Spanned;
 
 /// Entry point to derive `minicbor::Encode` on structs and enums.
 pub fn derive_from(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -31,16 +31,11 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             unreachable!("`derive_from` matched against `syn::Data::Struct`")
         };
 
-    let name     = &inp.ident;
-    let attrs    = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
-    let encoding = attrs.encoding().unwrap_or_default();
-    let fields   = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
-
-    // Collect type parameters which should not have an `Encode` bound added,
-    // i.e. from fields which have a custom encode function defined.
-    let blacklist = collect_type_params(&inp.generics, fields.fields().filter(|f| {
-        f.attrs.codec().map(|c| c.is_encode()).unwrap_or(false)
-    }));
+    let name      = &inp.ident;
+    let attrs     = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
+    let encoding  = attrs.encoding().unwrap_or_default();
+    let fields    = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
+    let blacklist = fields.gen_blacklist(&inp.generics, Mode::Encode);
 
     {
         let bound  = gen_encode_bound()?;
@@ -96,17 +91,13 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
     let flat          = enum_attrs.flat();
     let variants      = Variants::try_from(name.span(), data.variants.iter(), &enum_attrs)?;
 
-    let mut blacklist = HashSet::new();
+    let mut blacklist = Blacklist::default();
     let mut field_attrs = Vec::new();
     let mut rows = Vec::new();
 
     for ((var, idx), attrs) in data.variants.iter().zip(variants.indices.iter()).zip(&variants.attrs) {
         let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[attrs, &enum_attrs])?;
-        // Collect type parameters which should not have an `Encode` bound added,
-        // i.e. from fields which have a custom encode function defined.
-        blacklist.extend(collect_type_params(&inp.generics, fields.fields().filter(|f| {
-            f.attrs.codec().map(|c| c.is_encode()).unwrap_or(false)
-        })));
+        blacklist.merge(&inp.generics, Mode::Encode, &fields);
         let con = &var.ident;
         let encoding = attrs.encoding().unwrap_or(enum_encoding);
         let tag = encode_tag(attrs);
@@ -628,4 +619,3 @@ fn encode_tag(a: &Attributes) -> proc_macro2::TokenStream {
         quote!()
     }
 }
-

--- a/minicbor-derive/src/fields.rs
+++ b/minicbor-derive/src/fields.rs
@@ -192,7 +192,7 @@ impl<'a> FieldIter<'a> {
 }
 
 #[derive(Default)]
-pub(crate) struct Blacklist(HashSet<syn::TypeParam>);
+pub(crate) struct Blacklist(HashSet<syn::Ident>);
 
 impl Blacklist {
     pub(crate) fn merge<M>(&mut self, g: &syn::Generics, m: M, f: &Fields)
@@ -209,14 +209,14 @@ impl Blacklist {
     }
 }
 
-impl From<Blacklist> for HashSet<syn::TypeParam> {
+impl From<Blacklist> for HashSet<syn::Ident> {
     fn from(b: Blacklist) -> Self {
         b.0
     }
 }
 
 impl Deref for Blacklist {
-    type Target = HashSet<syn::TypeParam>;
+    type Target = HashSet<syn::Ident>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/minicbor-derive/src/fields.rs
+++ b/minicbor-derive/src/fields.rs
@@ -1,5 +1,9 @@
+use std::collections::HashSet;
+use std::ops::Deref;
+
 use crate::attrs::{Attributes, Idx, Kind, Level};
 use crate::attrs::idx;
+use crate::{collect_type_params, count_type_params, is_phantom_data, Mode};
 use proc_macro2::Span;
 use syn::{Ident, Type};
 use syn::spanned::Spanned;
@@ -97,6 +101,51 @@ impl Fields {
         all.sort_unstable_by_key(|(p, _)| *p);
         all.into_iter().map(|(_, i)| i).collect()
     }
+
+    /// Generate a blacklist of type parameters that should not have bounds attached.
+    ///
+    /// This includes:
+    ///
+    /// - Type parameters of fields with a custom encode or decode function.
+    /// - Fields that are skipped over.
+    /// - Fields with a `PhantomData` type.
+    pub(crate) fn gen_blacklist<M>(&self, g: &syn::Generics, mode: M) -> Blacklist
+    where
+        M: Into<Option<Mode>>
+    {
+        let mode = mode.into();
+
+        // Start with custom encode/decode functions.
+        let mut blacklist = collect_type_params(g, self.fields().filter(|f| {
+            match mode {
+                Some(Mode::Encode) => f.attrs.codec().map(|c| c.is_encode()).unwrap_or(false),
+                Some(Mode::Decode) => f.attrs.codec().map(|c| c.is_decode()).unwrap_or(false),
+                None               => false
+            }
+        }));
+
+        // Extend the blacklist by type parameters only appearing in skipped fields.
+        let skipped = collect_type_params(g, self.skipped());
+        if !skipped.is_empty() {
+            let regular = collect_type_params(g, self.fields());
+            blacklist.extend(skipped.difference(&regular).cloned())
+        }
+
+        // And finally also by type parameters only appearing in `PhantomData`.
+        let phantoms = count_type_params(g, self.fields().chain(self.skipped()).filter(|f| {
+            is_phantom_data(&f.typ)
+        }));
+        if !phantoms.is_empty() {
+            let totals = count_type_params(g, self.fields().chain(self.skipped()));
+            for (t, n) in phantoms {
+                if n >= totals.get(&t).copied().unwrap_or(0) {
+                    blacklist.insert(t);
+                }
+            }
+        }
+
+        Blacklist(blacklist)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -139,5 +188,37 @@ impl<'a> FieldIter<'a> {
 
     pub fn positions(&self) -> impl Iterator<Item = usize> + use<'a> {
         self.clone().map(|f| f.pos)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct Blacklist(HashSet<syn::TypeParam>);
+
+impl Blacklist {
+    pub(crate) fn merge<M>(&mut self, g: &syn::Generics, m: M, f: &Fields)
+    where
+        M: Into<Option<Mode>>
+    {
+        let b = f.gen_blacklist(g, m);
+        for t in collect_type_params(g, f.fields()).difference(&b) {
+            self.0.remove(t);
+        }
+        for t in b.0 {
+            self.0.insert(t);
+        }
+    }
+}
+
+impl From<Blacklist> for HashSet<syn::TypeParam> {
+    fn from(b: Blacklist) -> Self {
+        b.0
+    }
+}
+
+impl Deref for Blacklist {
+    type Target = HashSet<syn::TypeParam>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/minicbor-derive/src/fields.rs
+++ b/minicbor-derive/src/fields.rs
@@ -109,7 +109,7 @@ impl Fields {
     /// - Type parameters of fields with a custom encode or decode function.
     /// - Fields that are skipped over.
     /// - Fields with a `PhantomData` type.
-    pub(crate) fn gen_blacklist<M>(&self, g: &syn::Generics, mode: M) -> Blacklist
+    pub(crate) fn blacklist<M>(&self, g: &syn::Generics, mode: M) -> Blacklist
     where
         M: Into<Option<Mode>>
     {
@@ -199,7 +199,7 @@ impl Blacklist {
     where
         M: Into<Option<Mode>>
     {
-        let b = f.gen_blacklist(g, m);
+        let b = f.blacklist(g, m);
         for t in collect_type_params(g, f.fields()).difference(&b) {
             self.0.remove(t);
         }

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -626,30 +626,19 @@ where
     use syn::visit::Visit;
 
     struct Collector {
-        all: Vec<syn::Ident>,
+        all: HashSet<syn::Ident>,
         found: HashMap<syn::TypeParam, usize>
     }
 
     impl<'a> Visit<'a> for Collector {
-        fn visit_field(&mut self, f: &'a syn::Field) {
-            if let syn::Type::Path(ty) = &f.ty {
-                if let Some(t) = ty.path.segments.first() {
-                    if self.all.contains(&t.ident) {
-                        *self.found.entry(syn::TypeParam::from(t.ident.clone())).or_default() += 1
-                    }
-                }
-            }
-            self.visit_type(&f.ty)
-        }
-
-        fn visit_path(&mut self, p: &'a syn::Path) {
-            if p.leading_colon.is_none() && p.segments.len() == 1 {
-                let id = &p.segments[0].ident;
+        fn visit_type_path(&mut self, p: &'a syn::TypePath) {
+            if p.path.leading_colon.is_none() && p.path.segments.len() == 1 {
+                let id = &p.path.segments[0].ident;
                 if self.all.contains(id) {
                     *self.found.entry(syn::TypeParam::from(id.clone())).or_default() += 1
                 }
             }
-            syn::visit::visit_path(self, p)
+            syn::visit::visit_type_path(self, p)
         }
     }
 

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -619,7 +619,7 @@ fn is_byte_slice(ty: &syn::Type) -> bool {
 }
 
 /// Traverse all field types and count all type parameters along the way.
-fn count_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashMap<syn::TypeParam, usize>
+fn count_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashMap<syn::Ident, usize>
 where
     I: Iterator<Item = &'a fields::Field>
 {
@@ -627,7 +627,7 @@ where
 
     struct Collector {
         all: HashSet<syn::Ident>,
-        found: HashMap<syn::TypeParam, usize>
+        found: HashMap<syn::Ident, usize>
     }
 
     impl<'a> Visit<'a> for Collector {
@@ -635,7 +635,7 @@ where
             if p.path.leading_colon.is_none() && p.path.segments.len() == 1 {
                 let id = &p.path.segments[0].ident;
                 if self.all.contains(id) {
-                    *self.found.entry(syn::TypeParam::from(id.clone())).or_default() += 1
+                    *self.found.entry(id.clone()).or_default() += 1
                 }
             }
             syn::visit::visit_type_path(self, p)
@@ -655,7 +655,7 @@ where
 }
 
 /// Traverse all field types and collect all type parameters along the way.
-fn collect_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashSet<syn::TypeParam>
+fn collect_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashSet<syn::Ident>
 where
     I: Iterator<Item = &'a fields::Field>
 {
@@ -665,7 +665,7 @@ where
 fn add_bound_to_type_params<'a, I, A>
     ( bound: syn::TypeParamBound
     , params: I
-    , blacklist: &HashSet<syn::TypeParam>
+    , blacklist: &HashSet<syn::Ident>
     , attrs: A
     , mode: Mode
     )
@@ -684,7 +684,7 @@ where
     for p in params {
         if let Some(t) = find_type_param(p) {
             p.bounds.extend(t.bounds.iter().cloned())
-        } else if !blacklist.contains(p) {
+        } else if !blacklist.contains(&p.ident) {
             p.bounds.push(bound.clone())
         }
     }

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -513,7 +513,7 @@ pub(crate) mod fields;
 pub(crate) mod lifetimes;
 pub(crate) mod variants;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Derive the `minicbor::Decode` trait for a struct or enum.
 ///
@@ -618,8 +618,8 @@ fn is_byte_slice(ty: &syn::Type) -> bool {
     }
 }
 
-/// Traverse all field types and collect all type parameters along the way.
-fn collect_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashSet<syn::TypeParam>
+/// Traverse all field types and count all type parameters along the way.
+fn count_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashMap<syn::TypeParam, usize>
 where
     I: Iterator<Item = &'a fields::Field>
 {
@@ -627,7 +627,7 @@ where
 
     struct Collector {
         all: Vec<syn::Ident>,
-        found: HashSet<syn::TypeParam>
+        found: HashMap<syn::TypeParam, usize>
     }
 
     impl<'a> Visit<'a> for Collector {
@@ -635,7 +635,7 @@ where
             if let syn::Type::Path(ty) = &f.ty {
                 if let Some(t) = ty.path.segments.first() {
                     if self.all.contains(&t.ident) {
-                        self.found.insert(syn::TypeParam::from(t.ident.clone()));
+                        *self.found.entry(syn::TypeParam::from(t.ident.clone())).or_default() += 1
                     }
                 }
             }
@@ -646,7 +646,7 @@ where
             if p.leading_colon.is_none() && p.segments.len() == 1 {
                 let id = &p.segments[0].ident;
                 if self.all.contains(id) {
-                    self.found.insert(syn::TypeParam::from(id.clone()));
+                    *self.found.entry(syn::TypeParam::from(id.clone())).or_default() += 1
                 }
             }
             syn::visit::visit_path(self, p)
@@ -655,7 +655,7 @@ where
 
     let mut c = Collector {
         all: all.type_params().map(|tp| tp.ident.clone()).collect(),
-        found: HashSet::new()
+        found: HashMap::new()
     };
 
     for f in fields {
@@ -663,6 +663,14 @@ where
     }
 
     c.found
+}
+
+/// Traverse all field types and collect all type parameters along the way.
+fn collect_type_params<'a, I>(all: &syn::Generics, fields: I) -> HashSet<syn::TypeParam>
+where
+    I: Iterator<Item = &'a fields::Field>
+{
+    count_type_params(all, fields).into_keys().collect()
 }
 
 fn add_bound_to_type_params<'a, I, A>
@@ -722,4 +730,20 @@ where
 
 fn gen_ctx_param() -> syn::Result<syn::TypeParam> {
     syn::parse_str("Ctx")
+}
+
+fn is_phantom_data(t: &syn::Type) -> bool {
+    let syn::Type::Path(path) = t else {
+        return false
+    };
+    let Some(last) = path.path.segments.last() else {
+        return false
+    };
+    if last.ident != "PhantomData" || !matches!(last.arguments, syn::PathArguments::AngleBracketed(_)) {
+        return false
+    }
+    let prefix = path.path.segments.iter().map(|s| &s.ident).rev().skip(1);
+    let a = ["marker", "std"];
+    let b = ["marker", "core"];
+    prefix.clone().zip(a).all(|(p, a)| p == a) || prefix.zip(b).all(|(p, b)| p == b)
 }


### PR DESCRIPTION
As pointed out in #30, the derive logic currently puts unnecessary bounds on type parameters in `PhantomData` or skipped fields. This PR modifies the derive logic as follows:

1. Type parameters in `PhantomData` do not require any of `Encode`, `Decode`, `Default`, or `CborLen`.
2. Type parameters in types of fields with `#[cbor(skip)]` do not require any of `Encode`, `Decode` or `CborLen`.