### PR TITLE
Forward `is_nil`/`nil` calls.

### DIFF
--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -63,6 +63,10 @@ impl<'b, C, T: Decode<'b, C>> Decode<'b, C> for alloc::boxed::Box<T> {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, Error> {
         T::decode(d, ctx).map(alloc::boxed::Box::new)
     }
+
+    fn nil() -> Option<Self> {
+        T::nil().map(alloc::boxed::Box::new)
+    }
 }
 
 impl<'a, 'b: 'a, C> Decode<'b, C> for &'a str {
@@ -79,6 +83,10 @@ where
 {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, Error> {
         d.decode_with(ctx).map(alloc::borrow::Cow::Owned)
+    }
+
+    fn nil() -> Option<Self> {
+        T::Owned::nil().map(alloc::borrow::Cow::Owned)
     }
 }
 

--- a/minicbor/src/encode.rs
+++ b/minicbor/src/encode.rs
@@ -58,6 +58,10 @@ impl<C, T: Encode<C> + ?Sized> Encode<C> for &T {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
         (**self).encode(e, ctx)
     }
+
+    fn is_nil(&self) -> bool {
+        (**self).is_nil()
+    }
 }
 
 impl<C, T: CborLen<C> + ?Sized> CborLen<C> for &T {
@@ -69,6 +73,10 @@ impl<C, T: CborLen<C> + ?Sized> CborLen<C> for &T {
 impl<C, T: Encode<C> + ?Sized> Encode<C> for &mut T {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
         (**self).encode(e, ctx)
+    }
+
+    fn is_nil(&self) -> bool {
+        (**self).is_nil()
     }
 }
 
@@ -82,6 +90,10 @@ impl<C, T: CborLen<C> + ?Sized> CborLen<C> for &mut T {
 impl<C, T: Encode<C> + ?Sized> Encode<C> for alloc::boxed::Box<T> {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
         (**self).encode(e, ctx)
+    }
+
+    fn is_nil(&self) -> bool {
+        (**self).is_nil()
     }
 }
 
@@ -198,6 +210,10 @@ where
 {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
         self.as_ref().encode(e, ctx)
+    }
+
+    fn is_nil(&self) -> bool {
+        self.as_ref().is_nil()
     }
 }
 


### PR DESCRIPTION
As pointed out in #34, serveral `Encode`/`Decode` impls do not call the inner `is_nil`/`nil` methods.