### PR TITLE
Provide size_hint during deserialization

### DIFF
--- a/minicbor-serde/src/de.rs
+++ b/minicbor-serde/src/de.rs
@@ -343,7 +343,7 @@ impl<'a, 'de> MapAccess<'de> for Seq<'a, 'de> {
     type Error = DecodeError;
 
     fn size_hint(&self) -> Option<usize> {
-        self.len.map(|len| len as usize)
+        self.len.and_then(|n| n.try_into().ok())
     }
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>

--- a/minicbor-serde/src/de.rs
+++ b/minicbor-serde/src/de.rs
@@ -314,6 +314,10 @@ impl<'a, 'de> Seq<'a, 'de> {
 impl<'a, 'de> SeqAccess<'de> for Seq<'a, 'de> {
     type Error = DecodeError;
 
+    fn size_hint(&self) -> Option<usize> {
+        self.len.map(|len| len as usize)
+    }
+
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     where
         T: DeserializeSeed<'de>
@@ -337,6 +341,10 @@ impl<'a, 'de> SeqAccess<'de> for Seq<'a, 'de> {
 
 impl<'a, 'de> MapAccess<'de> for Seq<'a, 'de> {
     type Error = DecodeError;
+
+    fn size_hint(&self) -> Option<usize> {
+        self.len.map(|len| len as usize)
+    }
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where

--- a/minicbor-serde/src/de.rs
+++ b/minicbor-serde/src/de.rs
@@ -315,7 +315,7 @@ impl<'a, 'de> SeqAccess<'de> for Seq<'a, 'de> {
     type Error = DecodeError;
 
     fn size_hint(&self) -> Option<usize> {
-        self.len.map(|len| len as usize)
+        self.len.and_then(|n| n.try_into().ok())
     }
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>


### PR DESCRIPTION
Serde allows deserializers to provide a size hint, typically to call `with_capacity` with the right size. As we know it, exposing it. 