### PR TITLE
Add `skip_if` attribute.

### DIFF
--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -10,13 +10,15 @@ use std::fmt;
 use std::hash::Hash;
 use std::iter;
 
-use syn::{LitInt, LitStr};
+use syn::{parse_quote, LitInt, LitStr};
 use syn::spanned::Spanned;
 
 pub use typeparam::TypeParams;
 pub use codec::CustomCodec;
 pub use encoding::Encoding;
 pub use idx::Idx;
+
+use crate::attrs::codec::{Decode, Encode};
 
 /// Recognised attributes.
 #[derive(Debug, Clone)]
@@ -41,6 +43,7 @@ pub enum Kind {
     CborLen,
     Tag,
     Skip,
+    SkipIf,
     Flat,
     Default
 }
@@ -61,6 +64,7 @@ enum Value {
     CborLen(syn::ExprPath, proc_macro2::Span),
     Tag(u64, proc_macro2::Span),
     Skip(proc_macro2::Span),
+    SkipIf(Option<syn::ExprPath>, proc_macro2::Span),
     Flat(proc_macro2::Span),
     Default(proc_macro2::Span)
 }
@@ -130,6 +134,89 @@ impl Attributes {
                 return Err(syn::Error::new(*s, "flat enum does not support map encoding"))
             }
         }
+        // `skip_if` triggers the creation of a custom codec where `encode` and `decode`
+        // correspond the the default routines, `is_nil` is defined via `skip_if`'s
+        // predicate and `nil` points to an internal helper that matches the signature
+        // of `nil` and uses `Default::default` to create a default value.
+        //
+        // If a custom codec is already defined, `is_nil` and `nil` are overriden by
+        // `skip_if`'s predicate and the internal default helper.
+        if let Some(Value::SkipIf(is_nil@Some(_), skip_if_span)) = this.get_mut(Kind::SkipIf) {
+            let is_nil  = is_nil.take().expect("some is_nil");
+            let encode  = parse_quote!(minicbor::Encode::encode);
+            let decode  = parse_quote!(minicbor::Decode::decode);
+            let default = parse_quote!(minicbor::decode::internal::some_default);
+            let skip_if_span = *skip_if_span;
+            match this.remove(Kind::Codec) {
+                None => {
+                    let e = Encode { encode, is_nil: Some(is_nil), require_bound: true };
+                    let d = Decode { decode, nil: Some(default), require_bound: true };
+                    let c = CustomCodec::Both(Box::new(e), Box::new(d));
+                    this.attrs.insert(Kind::Codec, Value::Codec(c, skip_if_span));
+                }
+                Some(Value::Codec(CustomCodec::Encode(mut e), span)) => {
+                    if e.is_nil.is_some() {
+                        let msg = "skip_if and `is_nil` are mutually exclusive";
+                        return Err(syn::Error::new(skip_if_span, msg))
+                    }
+                    let c = {
+                        let d = Decode { decode, nil: Some(default), require_bound: true };
+                        e.is_nil = Some(is_nil);
+                        CustomCodec::Both(Box::new(e), Box::new(d))
+                    };
+                    this.attrs.insert(Kind::Codec, Value::Codec(c, span));
+                }
+                Some(Value::Codec(CustomCodec::Decode(mut d), span)) => {
+                    if d.nil.is_some() {
+                        let msg = "skip_if and `nil` are mutually exclusive";
+                        return Err(syn::Error::new(skip_if_span, msg))
+                    }
+                    let c = {
+                        let e = Encode { encode, is_nil: Some(is_nil), require_bound: true };
+                        d.nil = Some(default);
+                        CustomCodec::Both(Box::new(e), Box::new(d))
+                    };
+                    this.attrs.insert(Kind::Codec, Value::Codec(c, span));
+                }
+                Some(Value::Codec(CustomCodec::Both(mut e, mut d), span)) => {
+                    if e.is_nil.is_some() {
+                        let msg = "skip_if and `is_nil` are mutually exclusive";
+                        return Err(syn::Error::new(skip_if_span, msg))
+                    }
+                    if d.nil.is_some() {
+                        let msg = "skip_if and `nil` are mutually exclusive";
+                        return Err(syn::Error::new(skip_if_span, msg))
+                    }
+                    let c = {
+                        e.is_nil = Some(is_nil);
+                        d.nil = Some(default);
+                        CustomCodec::Both(e, d)
+                    };
+                    this.attrs.insert(Kind::Codec, Value::Codec(c, span));
+                }
+                Some(Value::Codec(m@CustomCodec::Module(_, has_nil), span)) => {
+                    if has_nil {
+                        let msg = "skip_if and `has_nil` are mutually exclusive";
+                        return Err(syn::Error::new(skip_if_span, msg))
+                    }
+                    let c = {
+                        let e = Encode {
+                            encode: m.to_encode_path().expect("module => encode path"),
+                            is_nil: Some(is_nil),
+                            require_bound: false,
+                        };
+                        let d = Decode {
+                            decode: m.to_decode_path().expect("module => decode path"),
+                            nil: Some(default),
+                            require_bound: false
+                        };
+                        CustomCodec::Both(Box::new(e), Box::new(d))
+                    };
+                    this.attrs.insert(Kind::Codec, Value::Codec(c, span));
+                }
+                _ => {}
+            }
+        }
         Ok(this)
     }
 
@@ -168,18 +255,29 @@ impl Attributes {
                 attrs.try_insert(Kind::HasNil, Value::HasNil(meta.path.span()))?
             } else if meta.path.is_ident("encode_with") {
                 let s: LitStr = meta.value()?.parse()?;
-                let c = CustomCodec::Encode(codec::Encode { encode: s.parse()?, is_nil: None });
+                let c = CustomCodec::Encode(codec::Encode {
+                    encode: s.parse()?,
+                    is_nil: None,
+                    require_bound: false
+                });
                 attrs.try_insert(Kind::Codec, Value::Codec(c, meta.path.span()))?
             } else if meta.path.is_ident("is_nil") {
                 let s: LitStr = meta.value()?.parse()?;
                 attrs.try_insert(Kind::IsNil, Value::IsNil(s.parse()?, meta.path.span()))?
             } else if meta.path.is_ident("decode_with") {
                 let s: LitStr = meta.value()?.parse()?;
-                let c = CustomCodec::Decode(codec::Decode { decode: s.parse()?, nil: None });
+                let c = CustomCodec::Decode(codec::Decode {
+                    decode: s.parse()?,
+                    nil: None,
+                    require_bound: false
+                });
                 attrs.try_insert(Kind::Codec, Value::Codec(c, meta.path.span()))?
             } else if meta.path.is_ident("nil") {
                 let s: LitStr = meta.value()?.parse()?;
                 attrs.try_insert(Kind::Nil, Value::Nil(s.parse()?, meta.path.span()))?
+            } else if meta.path.is_ident("skip_if") {
+                let s: LitStr = meta.value()?.parse()?;
+                attrs.try_insert(Kind::SkipIf, Value::SkipIf(Some(s.parse()?), meta.path.span()))?;
             } else if meta.path.is_ident("with") {
                 let s: LitStr = meta.value()?.parse()?;
                 let c = CustomCodec::Module(s.parse()?, false);
@@ -305,6 +403,10 @@ impl Attributes {
         self.contains_key(Kind::Skip)
     }
 
+    pub fn skip_if_codec(&self) -> bool {
+        self.contains_key(Kind::SkipIf)
+    }
+
     pub fn flat(&self) -> bool {
         self.contains_key(Kind::Flat)
     }
@@ -347,6 +449,7 @@ impl Attributes {
                 | Kind::HasNil
                 | Kind::CborLen
                 | Kind::Skip
+                | Kind::SkipIf
                 | Kind::Flat
                 | Kind::Default
                 => {
@@ -365,6 +468,7 @@ impl Attributes {
                 | Kind::CborLen
                 | Kind::Tag
                 | Kind::Skip
+                | Kind::SkipIf
                 | Kind::Default
                 => {}
                 | Kind::Encoding
@@ -394,6 +498,7 @@ impl Attributes {
                 | Kind::HasNil
                 | Kind::CborLen
                 | Kind::Skip
+                | Kind::SkipIf
                 | Kind::Default
                 => {
                     let msg = format!("attribute is not supported on {}-level", self.level);
@@ -416,6 +521,7 @@ impl Attributes {
                 | Kind::ContextBound
                 | Kind::CborLen
                 | Kind::Skip
+                | Kind::SkipIf
                 | Kind::Flat
                 | Kind::Default
                 => {
@@ -429,12 +535,20 @@ impl Attributes {
                 let s = val.span();
                 match (val, &cc) {
                     (Value::Codec(CustomCodec::Encode(e), _), CustomCodec::Decode(d)) => {
-                        let d = codec::Decode { decode: d.decode.clone(), nil: d.nil.clone() };
+                        let d = codec::Decode {
+                            decode: d.decode.clone(),
+                            nil: d.nil.clone(),
+                            require_bound: d.require_bound
+                        };
                         *cc = CustomCodec::Both(Box::new(e), Box::new(d));
                         return Ok(())
                     }
                     (Value::Codec(CustomCodec::Decode(d), _), CustomCodec::Encode(e)) => {
-                        let e = codec::Encode { encode: e.encode.clone(), is_nil: e.is_nil.clone() };
+                        let e = codec::Encode {
+                            encode: e.encode.clone(),
+                            is_nil: e.is_nil.clone(),
+                            require_bound: e.require_bound
+                        };
                         *cc = CustomCodec::Both(Box::new(e), Box::new(d));
                         return Ok(())
                     }
@@ -590,6 +704,7 @@ impl Value {
             Value::CborLen(_, s)      => *s,
             Value::Tag(_, s)          => *s,
             Value::Skip(s)            => *s,
+            Value::SkipIf(_, s)       => *s,
             Value::Flat(s)            => *s,
             Value::Default(s)         => *s
         }

--- a/minicbor-derive/src/attrs/codec.rs
+++ b/minicbor-derive/src/attrs/codec.rs
@@ -50,13 +50,15 @@ pub enum CustomCodec {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Encode {
     pub encode: syn::ExprPath,
-    pub is_nil: Option<syn::ExprPath>
+    pub is_nil: Option<syn::ExprPath>,
+    pub require_bound: bool
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Decode {
     pub decode: syn::ExprPath,
-    pub nil: Option<syn::ExprPath>
+    pub nil: Option<syn::ExprPath>,
+    pub require_bound: bool
 }
 
 impl CustomCodec {
@@ -156,6 +158,24 @@ impl CustomCodec {
             Some(p)
         } else {
             None
+        }
+    }
+
+    pub fn require_encode_bound(&self) -> bool {
+        match self {
+            CustomCodec::Encode(e)  => e.require_bound,
+            CustomCodec::Decode(_)  => true,
+            CustomCodec::Both(e, _) => e.require_bound,
+            CustomCodec::Module(..) => true
+        }
+    }
+
+    pub fn require_decode_bound(&self) -> bool {
+        match self {
+            CustomCodec::Encode(_)  => true,
+            CustomCodec::Decode(d)  => d.require_bound,
+            CustomCodec::Both(_, d) => d.require_bound,
+            CustomCodec::Module(..) => true
         }
     }
 }

--- a/minicbor-derive/src/blacklist.rs
+++ b/minicbor-derive/src/blacklist.rs
@@ -19,8 +19,8 @@ impl Blacklist {
         // Start with custom encode/decode/cbor_len functions.
         let mut blacklist = collect_type_params(g, fields.fields().filter(|f| {
             match mode {
-                Mode::Encode => f.attrs.codec().map(|c| c.is_encode()).unwrap_or(false),
-                Mode::Decode => f.attrs.codec().map(|c| c.is_decode()).unwrap_or(false),
+                Mode::Encode => f.attrs.codec().map(|c| !c.require_encode_bound()).unwrap_or(false),
+                Mode::Decode => f.attrs.codec().map(|c| !c.require_decode_bound()).unwrap_or(false),
                 Mode::Length => f.attrs.cbor_len().is_some()
                     || f.attrs.codec()
                         .map(|c| matches!(c, CustomCodec::Module(..)))
@@ -30,8 +30,8 @@ impl Blacklist {
         if !blacklist.is_empty() {
             let others = collect_type_params(g, fields.fields().filter(|f| {
                 match mode {
-                    Mode::Encode => f.attrs.codec().map(|c| !c.is_encode()).unwrap_or(true),
-                    Mode::Decode => f.attrs.codec().map(|c| !c.is_decode()).unwrap_or(true),
+                    Mode::Encode => f.attrs.codec().map(|c| c.require_encode_bound()).unwrap_or(true),
+                    Mode::Decode => f.attrs.codec().map(|c| c.require_decode_bound()).unwrap_or(true),
                     Mode::Length => f.attrs.cbor_len().is_none()
                         && f.attrs.codec()
                             .map(|c| !matches!(c, CustomCodec::Module(..)))

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -49,7 +49,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
     // Collect type parameters which require a `Default` bound.
     let default_types =
         collect_type_params(&inp.generics, fields.fields().chain(fields.skipped()).filter(|f| {
-            (f.attrs.default() || f.attrs.skip()) && !is_phantom_data(&f.typ)
+            (f.attrs.default() || f.attrs.skip() || f.attrs.skip_if_codec()) && !is_phantom_data(&f.typ)
         }))
         .into_iter()
         .collect();
@@ -170,7 +170,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             // Collect type parameters which require a `Default` bound.
             defaults.extend(
                 collect_type_params(&inp.generics, fields.fields().chain(fields.skipped()).filter(|f| {
-                    (f.attrs.default() || f.attrs.skip()) && !is_phantom_data(&f.typ)
+                    (f.attrs.default() || f.attrs.skip() || f.attrs.skip_if_codec()) && !is_phantom_data(&f.typ)
                 }))
                 .into_iter()
             );

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -94,6 +94,7 @@
 //! - [`#[cbor(index_only)]`](#cborindex_only)
 //! - [`#[cbor(transparent)]`](#cbortransparent)
 //! - [`#[cbor(skip)]`](#cborskip)
+//! - [`#[cbor(skip_if)]`](#cborskip_if)
 //! - [`#[cbor(default)]`](#cbordefault)
 //! - [`#[cbor(tag(...))]`](#cbortag)
 //! - [`#[cbor(decode_with)]`](#cbordecode_with--path)
@@ -175,6 +176,24 @@
 //! This attribute can be attached to fields in structs and enums and prevents
 //! those fields from being encoded. Field types must implement [`Default`] and
 //! when decoding the fields are initialised with `Default::default()`.
+//!
+//! ## `#[cbor(skip_if = "<path>")]`
+//!
+//! This attribute can be attached to fields in structs and enums and prevents
+//! those fields from being encoded if the predicate function denoted by `path`
+//! returns true. The predicate function must satisfy the following signature
+//!
+//! ```no_run
+//! fn pred<T>(_: &T) -> bool {
+//!     todo!()
+//! }
+//! ```
+//!
+//! Field types must implement [`Default`] and when decoding, the fields are
+//! initialised with `Default::default()` if no value is present.
+//!
+//! Please note that `skip_if` is mutually exclusive with `nil`, `is_nil`, and
+//! `has_nil`.
 //!
 //! ## `#[cbor(default)]`
 //!

--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -7,6 +7,7 @@ use core::mem::MaybeUninit;
 mod decoder;
 mod error;
 pub mod info;
+pub mod internal;
 
 use crate::data::{Int, Tag, Tagged};
 

--- a/minicbor/src/decode/internal.rs
+++ b/minicbor/src/decode/internal.rs
@@ -1,0 +1,6 @@
+//! Internal module that external crates should not rely on.
+
+/// Wrap a default value in `Option::Some`.
+pub fn some_default<T: Default>() -> Option<T> {
+    Some(Default::default())
+}


### PR DESCRIPTION
Adds `#[cbor(skip_if = "<path>")]`.

This attribute can be attached to fields in structs and enums and prevents those fields from being encoded if the predicate function denoted by `path` returns true. This function must satisfy the following signature:

```rust
fn pred<T>(_: &T) -> bool {
    todo!()
}
```
Field types must implement `Default`, and when decoding, the fields are initialised with `Default::default()` if no value is present.

Please note that `skip_if` is mutually exclusive with `nil`, `is_nil`, and `has_nil`.

Addresses https://github.com/twittner/minicbor/issues/43.
