### PR TITLE
Fix discrepancy between host vs target "std" feature

### DIFF
--- a/minicbor-derive/Cargo.toml
+++ b/minicbor-derive/Cargo.toml
@@ -13,8 +13,8 @@ categories    = ["encoding"]
 proc-macro = true
 
 [features]
-alloc = []
-std   = ["alloc"]
+alloc = [] # unused
+std   = [] # unused
 
 [dependencies]
 proc-macro2 = "1.0.79"

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -330,15 +330,14 @@ fn gen_statements(fields: &Fields, encoding: Encoding, flat: bool) -> syn::Resul
             };
 
             let value =
-                if cfg!(any(feature = "alloc", feature = "std"))
-                    && (field.attrs.borrow().is_some() || field.index.is_b())
+                if (field.attrs.borrow().is_some() || field.index.is_b())
                     && is_cow(&field.typ, |t| is_str(t) || is_byte_slice(t))
                 {
-                    if cfg!(feature = "std") {
-                        quote!(Some(std::borrow::Cow::Borrowed(__v777)))
-                    } else {
-                        quote!(Some(alloc::borrow::Cow::Borrowed(__v777)))
-                    }
+                    quote!(minicbor::__minicbor_cfg! {
+                        'std { Some(std::borrow::Cow::Borrowed(__v777)) }
+                        'alloc { Some(alloc::borrow::Cow::Borrowed(__v777)) }
+                        'otherwise { Some(__v777) }
+                    })
                 } else {
                     quote!(Some(__v777))
                 };
@@ -443,42 +442,41 @@ fn make_transparent_impl
         .unwrap_or_else(|| default_decode_fn.clone());
 
     let decode_call =
-        if cfg!(any(feature = "alloc", feature = "std"))
-            && (field.attrs.borrow().is_some() || field.index.is_b())
+        if (field.attrs.borrow().is_some() || field.index.is_b())
             && is_cow(&field.typ, |t| is_str(t) || is_byte_slice(t))
         {
-            let cow =
-                if cfg!(feature = "std") {
-                    quote!(std::borrow::Cow::Borrowed(v))
-                } else {
-                    quote!(alloc::borrow::Cow::Borrowed(v))
-                };
-            if field.is_name {
-                let id = &field.ident;
-                quote! {
-                    Ok(#name {
-                        #id: match #decode_fn(__d777, __ctx777) {
-                            Ok(v)  => #cow,
-                            Err(e) => return Err(e)
-                        }
-                    })
-                }
-            } else {
-                quote! {
-                    Ok(#name(match #decode_fn(__d777, __ctx777) {
-                        Ok(v)  => #cow,
+            quote!(minicbor::__minicbor_cfg! {
+                'std {
+                    match #decode_fn(__d777, __ctx777) {
+                        Ok(v)  => std::borrow::Cow::Borrowed(v),
                         Err(e) => return Err(e)
-                    }))
+                    }
                 }
+                'alloc {
+                    match #decode_fn(__d777, __ctx777) {
+                        Ok(v)  => alloc::borrow::Cow::Borrowed(v),
+                        Err(e) => return Err(e)
+                    }
+                }
+                'otherwise {
+                    #decode_fn(__d777, __ctx777)?
+                }
+            })
+        } else {
+            quote! {
+                #decode_fn(__d777, __ctx777)?
             }
-        } else if field.is_name {
+        };
+
+    let decode_body =
+        if field.is_name {
             let id = &field.ident;
             quote! {
-                Ok(#name { #id: #decode_fn(__d777, __ctx777)? })
+                Ok(#name { #id: #decode_call })
             }
         } else {
             quote! {
-                Ok(#name(#decode_fn(__d777, __ctx777)?))
+                Ok(#name(#decode_call))
             }
         };
 
@@ -521,7 +519,7 @@ fn make_transparent_impl
     Ok(quote! {
         impl #impl_generics minicbor::Decode<'bytes, Ctx> for #name #typ_generics #where_clause {
             fn decode(__d777: &mut minicbor::Decoder<'bytes>, __ctx777: &mut Ctx) -> core::result::Result<#name #typ_generics, minicbor::decode::Error> {
-                #decode_call
+                #decode_body
             }
 
             #nil_impl
@@ -576,27 +574,25 @@ fn nil(f: &Field) -> proc_macro2::TokenStream {
 
 fn decode_tag(a: &Attributes) -> proc_macro2::TokenStream {
     if let Some(t) = a.tag() {
-        let err =
-            if cfg!(feature = "std") {
-                quote! {
-                    minicbor::decode::Error::tag_mismatch(__t777)
-                        .with_message(format!("expected tag {}", #t))
-                        .at(__p777)
-                }
-            } else if cfg!(feature = "alloc") {
-                quote! {
-                    minicbor::decode::Error::tag_mismatch(__t777)
-                        .with_message(alloc::format!("expected tag {}", #t))
-                        .at(__p777)
-                }
-            } else {
-                quote!(minicbor::decode::Error::tag_mismatch(__t777).at(__p777))
-            };
         quote! {
             let __p777 = __d777.position();
             let __t777 = __d777.tag()?;
             if #t != __t777.as_u64() {
-                return Err(#err)
+                return Err(minicbor::__minicbor_cfg! {
+                    'std {
+                        minicbor::decode::Error::tag_mismatch(__t777)
+                            .with_message(format!("expected tag {}", #t))
+                            .at(__p777)
+                    }
+                    'alloc {
+                        minicbor::decode::Error::tag_mismatch(__t777)
+                            .with_message(alloc::format!("expected tag {}", #t))
+                            .at(__p777)
+                    }
+                    'otherwise {
+                        minicbor::decode::Error::tag_mismatch(__t777).at(__p777)
+                    }
+                });
             }
         }
     } else {

--- a/minicbor/Cargo.toml
+++ b/minicbor/Cargo.toml
@@ -14,8 +14,8 @@ features = ["std", "derive", "half"]
 
 [features]
 full   = ["std", "derive", "half"]
-alloc  = ["minicbor-derive?/alloc"]
-std    = ["alloc", "minicbor-derive?/std"]
+alloc  = []
+std    = ["alloc"]
 derive = ["minicbor-derive"]
 
 [dependencies]

--- a/minicbor/src/derive.rs
+++ b/minicbor/src/derive.rs
@@ -1,0 +1,38 @@
+#[cfg(feature = "std")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __minicbor_cfg {
+    (
+        'std {$($std:tt)*}
+        'alloc {$($alloc:tt)*}
+        'otherwise {$($otherwise:tt)*}
+    ) => {
+        $($std)*
+    };
+}
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __minicbor_cfg {
+    (
+        'std {$($std:tt)*}
+        'alloc {$($alloc:tt)*}
+        'otherwise {$($otherwise:tt)*}
+    ) => {
+        $($alloc)*
+    };
+}
+
+#[cfg(all(not(feature = "alloc"), not(feature = "std")))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __minicbor_cfg {
+    (
+        'std {$($std:tt)*}
+        'alloc {$($alloc:tt)*}
+        'otherwise {$($otherwise:tt)*}
+    ) => {
+        $($otherwise)*
+    };
+}

--- a/minicbor/src/lib.rs
+++ b/minicbor/src/lib.rs
@@ -160,6 +160,8 @@ pub use encode::{Encode, Encoder, CborLen};
 
 #[cfg(feature = "derive")]
 pub use minicbor_derive::*;
+#[cfg(feature = "derive")]
+mod derive;
 
 #[cfg(feature = "alloc")]
 use core::convert::Infallible;


### PR DESCRIPTION
`derive(Decode)` was incorrectly looking at whether the "std" feature is enabled in the **host** platform to decide on how to generate decoding code. This is not correct. When using the Cargo v2 feature resolver (edition 2021+), or when using the v1 feature resolver and cross-compiling, it can happen that "std" is enabled in the host platform and not enabled in the target platform, leading to generated code that does not compile.

The std- and alloc-related generated code needs to depend on whether "std" is enabled in the **target** platform.

Repro:

```toml
# Cargo.toml

[package]
name = "repro"
version = "0.0.0"
edition = "2024"
publish = false

[dependencies]
minicbor = { version = "2.1.2", default-features = false, features = ["alloc", "derive"] }

[build-dependencies]
minicbor = { version = "2.1.2", features = ["derive", "std"] }
```

```rust
// build.rs

use std::collections::HashSet;

#[derive(Default, minicbor::Encode)]
#[cbor(transparent)]
struct Thing {
    // Encode something that requires cfg(feature = "std") on the host platform
    set: HashSet<String>,
}

fn main() {
    let thing = Thing::default();
    let mut buffer = [0u8; 4];
    minicbor::encode(&thing, buffer.as_mut()).unwrap();
    println!("cargo:warning={:?}", buffer);
}
```

```rust
// src/lib.rs

#![no_std]

extern crate alloc;

use alloc::borrow::Cow;

#[derive(minicbor::Decode)]
#[cbor(transparent)]
pub struct Thing<'a>(#[cbor(borrow)] pub Cow<'a, str>);
```

`cargo check --target x86_64-unknown-none` previously failed like this, because the std feature on the host platform was being applied improperly against generated code built for the target platform.

```console
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `std`
 --> src/lib.rs:9:10
  |
9 | #[derive(minicbor::Decode)]
  |          ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `std`
  |
  = help: if you wanted to use a crate named `std`, use `cargo add std` to add it to your `Cargo.toml`
  = note: this error originates in the derive macro `minicbor::Decode` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing this enum
  |
7 + use alloc::borrow::Cow;
  |
```