### PR TITLE
minicbor-serde: add support for serializing / deserializing custom CBOR tags

### DIFF
--- a/minicbor-serde/src/de.rs
+++ b/minicbor-serde/src/de.rs
@@ -1,9 +1,15 @@
-use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
+use serde::de::{
+    self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor,
+    value::{BorrowedStrDeserializer, U64Deserializer},
+};
 
-use minicbor::data::Type;
+use minicbor::data::{Tag, Type};
 use minicbor::decode::{Decoder, Error};
 
-use crate::error::DecodeError;
+use crate::{
+    error::DecodeError,
+    tag::{NO_TAG_IDENTIFIER, TAG_CONTAINER_IDENTIFIER, TAG_IDENTIFIER},
+};
 
 const BREAK: u8 = 0xff;
 
@@ -269,13 +275,18 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
 
     fn deserialize_enum<V>
         ( self
-        , _name: &'static str
+        , name: &'static str
         , _variants: &'static [&'static str]
         , visitor: V
         ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>
     {
+        // Handle the case when user uses our custom tag structures
+        if name == TAG_CONTAINER_IDENTIFIER {
+            return visitor.visit_enum(EnumTagAccess::new(self)?);
+        }
+
         let p = self.decoder.position();
         if Type::Map == self.decoder.datatype()? {
             let m = self.decoder.map()?;
@@ -424,5 +435,126 @@ impl<'a, 'de> VariantAccess<'de> for Enum<'a, 'de> {
         V: Visitor<'de>
     {
         de::Deserializer::deserialize_map(self.deserializer, v)
+    }
+}
+
+enum State {
+    Tag(Tag),
+    Value,
+    End,
+}
+
+struct SeqTagAccess<'a, 'de: 'a> {
+    deserializer: &'a mut Deserializer<'de>,
+    state: State,
+}
+
+impl<'a, 'de> SeqTagAccess<'a, 'de> {
+    fn new(tag: Option<Tag>, d: &'a mut Deserializer<'de>) -> Self {
+        Self {
+            state: tag.map(State::Tag).unwrap_or(State::Value),
+            deserializer: d,
+        }
+    }
+}
+
+impl<'a, 'de> de::SeqAccess<'de> for SeqTagAccess<'a, 'de> {
+    type Error = DecodeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.state {
+            State::Tag(tag) => {
+                self.state = State::Value;
+                Ok(Some(
+                    seed.deserialize(U64Deserializer::<DecodeError>::new(tag.as_u64()))?,
+                ))
+            }
+            State::Value => {
+                self.state = State::End;
+                Ok(Some(seed.deserialize(&mut *self.deserializer)?))
+            }
+            State::End => Ok(None),
+        }
+    }
+}
+
+struct EnumTagAccess<'a, 'de: 'a> {
+    deserializer: &'a mut Deserializer<'de>,
+    tag: Option<Tag>,
+}
+
+impl<'a, 'de> EnumTagAccess<'a, 'de> {
+    fn new(d: &'a mut Deserializer<'de>) -> Result<Self, DecodeError> {
+        let tag = match d.decoder_mut().datatype()? {
+            Type::Tag => Some(d.decoder_mut().tag()?),
+            _ => None,
+        };
+
+        Ok(Self {
+            tag,
+            deserializer: d,
+        })
+    }
+}
+
+impl<'a, 'de> de::EnumAccess<'de> for EnumTagAccess<'a, 'de> {
+    type Error = DecodeError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = match self.tag.is_some() {
+            true => TAG_IDENTIFIER,
+            false => NO_TAG_IDENTIFIER,
+        };
+
+        Ok((
+            seed.deserialize(BorrowedStrDeserializer::<Self::Error>::new(variant))?,
+            self,
+        ))
+    }
+}
+
+impl<'a, 'de> de::VariantAccess<'de> for EnumTagAccess<'a, 'de> {
+    type Error = DecodeError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Err(de::Error::invalid_type(
+            de::Unexpected::UnitVariant,
+            &"NoTag or Tag variant",
+        ))
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.deserializer)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(SeqTagAccess::new(self.tag, self.deserializer))
+    }
+
+    fn struct_variant<V>(
+        self
+        , _fields: &'static [&'static str]
+        , _visitor: V
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            de::Unexpected::StructVariant,
+            &"NoTag or Tag variant",
+        ))
     }
 }

--- a/minicbor-serde/src/lib.rs
+++ b/minicbor-serde/src/lib.rs
@@ -45,6 +45,7 @@ extern crate alloc;
 
 mod de;
 mod ser;
+pub mod tag;
 pub mod error;
 
 pub use de::{Deserializer, from_slice};

--- a/minicbor-serde/src/ser.rs
+++ b/minicbor-serde/src/ser.rs
@@ -1,9 +1,9 @@
-use minicbor::encode::{Encoder, Write};
+use minicbor::encode::{self, Encoder, Write};
 use serde::Serialize;
 use serde::ser::{self, SerializeSeq, SerializeTuple, SerializeTupleStruct};
 use serde::ser::{SerializeMap, SerializeStruct, SerializeStructVariant, SerializeTupleVariant};
 
-use crate::error::EncodeError;
+use crate::{error::EncodeError, tag::{TAG_CONTAINER_IDENTIFIER, TAG_IDENTIFIER, NO_TAG_IDENTIFIER}};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -188,7 +188,7 @@ where
 
     fn serialize_newtype_variant<T>
         ( self
-        , _name: &'static str
+        , name: &'static str
         , _index: u32
         , variant: &'static str
         , value: &T
@@ -196,6 +196,10 @@ where
     where
         T: Serialize + ?Sized
     {
+        if name == TAG_CONTAINER_IDENTIFIER && variant == NO_TAG_IDENTIFIER {
+            return value.serialize(self);
+        }
+
         self.encoder.map(1)?.str(variant)?;
         value.serialize(self)
     }
@@ -206,12 +210,12 @@ where
         } else {
             self.encoder.begin_array()?;
         }
-        Ok(SeqSerializer { serializer: self, indefinite: len.is_none() })
+        Ok(SeqSerializer { serializer: self, indefinite: len.is_none(), tagged: false })
     }
 
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         self.encoder.array(len as u64)?;
-        Ok(SeqSerializer { serializer: self, indefinite: false })
+        Ok(SeqSerializer { serializer: self, indefinite: false, tagged: false })
     }
 
     fn serialize_tuple_struct
@@ -225,12 +229,15 @@ where
 
     fn serialize_tuple_variant
         ( self
-        , _name: &'static str
+        , name: &'static str
         , _index: u32
         , variant: &'static str
         , len: usize
         ) -> Result<Self::SerializeTupleVariant, Self::Error>
     {
+        if name == TAG_CONTAINER_IDENTIFIER && variant == TAG_IDENTIFIER {
+            return Ok(SeqSerializer { serializer: self, indefinite: false, tagged: true });
+        }
         self.encoder.map(1)?.str(variant)?;
         self.serialize_tuple(len)
     }
@@ -241,7 +248,7 @@ where
         } else {
             self.encoder.begin_map()?;
         }
-        Ok(SeqSerializer { serializer: self, indefinite: len.is_none() })
+        Ok(SeqSerializer { serializer: self, indefinite: len.is_none(), tagged: false })
     }
 
     fn serialize_struct
@@ -251,7 +258,7 @@ where
         ) -> Result<Self::SerializeStruct, Self::Error>
     {
         self.encoder.map(len as u64)?;
-        Ok(SeqSerializer { serializer: self, indefinite: false })
+        Ok(SeqSerializer { serializer: self, indefinite: false, tagged: false })
     }
 
     fn serialize_struct_variant
@@ -278,7 +285,8 @@ where
 
 pub struct SeqSerializer<'a, W: 'a> {
     serializer: &'a mut Serializer<W>,
-    indefinite: bool
+    indefinite: bool,
+    tagged: bool,
 }
 
 impl<'a, W: Write> SerializeSeq for SeqSerializer<'a, W>
@@ -340,7 +348,16 @@ where
     type Error = EncodeError<W::Error>;
 
     fn serialize_field<T: Serialize + ?Sized>(&mut self, x: &T) -> Result<(), Self::Error> {
-        x.serialize(&mut *self.serializer)
+        if self.tagged {
+            self.tagged = false;
+
+            let tag = x.serialize(TagExtractor::<W>::new())?;
+            self.serializer.encoder.tag(minicbor::data::Tag::new(tag))?;
+
+            Ok(())
+        } else {
+            x.serialize(&mut *self.serializer)
+        }
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
@@ -408,5 +425,153 @@ where
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
         Ok(())
+    }
+}
+
+/// Captures a tag from [`Serializer`] and passes it to [`Encoder::tag`]
+struct TagExtractor<W: Write>(core::marker::PhantomData<W>);
+
+impl<W: Write> TagExtractor<W>
+where
+    <W as Write>::Error: core::error::Error + 'static  {
+    fn new() -> Self {
+        TagExtractor(core::marker::PhantomData)
+    }
+}
+
+impl<W: Write> ser::Serializer for TagExtractor<W>
+where
+    <W as Write>::Error: core::error::Error + 'static {
+
+    type Ok = u64;
+    type Error = EncodeError<W::Error>;
+
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_u64(self, v: u64) -> Result<u64, Self::Error> {
+        Ok(v)
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<u64, Self::Error> {
+        Ok(v.into())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<u64, Self::Error> {
+        Ok(v.into())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<u64, Self::Error> {
+        Ok(v.into())
+    }
+
+    fn serialize_bool(self, _: bool) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_i8(self, _: i8) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_i16(self, _: i16) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_i32(self, _: i32) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_i64(self, _: i64) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_f32(self, _: f32) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_f64(self, _: f64) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_char(self, _: char) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_str(self, _: &str) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_none(self) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_some<T: Serialize + ?Sized>(self, _: &T) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_unit(self) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_newtype_struct<T: Serialize + ?Sized>(self, _: &'static str, _: &T) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_newtype_variant<T: Serialize + ?Sized>(self, _: &'static str, _: u32, _: &'static str, _: &T) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_tuple_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_tuple_variant(self, _: &'static str, _: u32, _: &'static str, _: usize) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn serialize_struct_variant(self, _: &'static str, _: u32, _: &'static str, _: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn collect_str<T: core::fmt::Display + ?Sized>(self, _: &T) -> Result<u64, Self::Error> {
+        Err(EncodeError::from(encode::Error::message("expected u64")))
     }
 }

--- a/minicbor-serde/src/tag.rs
+++ b/minicbor-serde/src/tag.rs
@@ -1,7 +1,7 @@
 //!  Module providing types to support custom tags in CBOR
 use core::ops::{Deref, DerefMut};
 use minicbor::data::Tag;
-use serde::{Deserialize, de};
+use serde::{Deserialize, Serialize, de};
 
 /// Enum alias for [`TagContainer`]
 pub(crate) const TAG_CONTAINER_IDENTIFIER: &str = "$#minicbor_serde_tag_container#$";
@@ -16,6 +16,10 @@ pub(crate) const NO_TAG_IDENTIFIER: &str = "$#minicbor_serde_no_tag#$";
 /// value.
 ///
 /// [`de::Deserialize`] implementation for this enum renames the fields to
+/// custom aliases to ensure that [`crate::de::Deserializer`] is able to drive
+/// the [`minicbor::Decoder`] correctly.
+///
+/// /// [`ser::Serializer`] implementation for this enum renames the fields to
 /// custom aliases to ensure that [`crate::de::Deserializer`] is able to drive
 /// the [`minicbor::Decoder`] correctly.
 enum TagContainer<T> {
@@ -136,6 +140,34 @@ impl core::fmt::Display for ExpectedTagError {
     }
 }
 
+impl<T: Serialize> Serialize for TagContainer<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeTupleVariant;
+        match self {
+            TagContainer::Tag(tag, val) => {
+                let mut tv = serializer.serialize_tuple_variant(
+                    TAG_CONTAINER_IDENTIFIER,
+                    0,
+                    TAG_IDENTIFIER,
+                    2,
+                )?;
+                tv.serialize_field(&tag.as_u64())?;
+                tv.serialize_field(val)?;
+                tv.end()
+            }
+            TagContainer::NoTag(val) => serializer.serialize_newtype_variant(
+                TAG_CONTAINER_IDENTIFIER,
+                1,
+                NO_TAG_IDENTIFIER,
+                val,
+            ),
+        }
+    }
+}
+
 /// Requires unique tag to be present during deserialization
 ///
 /// Tags will always be emitted during serialization
@@ -189,6 +221,15 @@ impl<'de, const TAG: u64, T: Deserialize<'de>> Deserialize<'de> for Required<TAG
             ))),
             _ => Err(de::Error::custom(ExpectedTagError::new(Self::EXPECTED_TAG))),
         }
+    }
+}
+
+impl<const TAG: u64, T: Serialize> Serialize for Required<TAG, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        TagContainer::Tag(Self::EXPECTED_TAG, &self.0).serialize(serializer)
     }
 }
 
@@ -255,6 +296,18 @@ impl<'de, const TAG: u64, T: Deserialize<'de>> Deserialize<'de> for Optional<TAG
     }
 }
 
+impl<const TAG: u64, T: Serialize> Serialize for Optional<TAG, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(tag) => TagContainer::Tag(tag, &self.1).serialize(serializer),
+            None => TagContainer::NoTag(&self.1).serialize(serializer),
+        }
+    }
+}
+
 /// Accepts any tag during deserialization, if present
 ///
 /// Tag will be emitted during serialization, if present
@@ -306,6 +359,18 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Any<T> {
         match container {
             TagContainer::Tag(tag, val) => Ok(Any(Some(tag), val)),
             TagContainer::NoTag(val) => Ok(Any(None, val)),
+        }
+    }
+}
+
+impl<T: Serialize> Serialize for Any<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(tag) => TagContainer::Tag(tag, &self.1).serialize(serializer),
+            None => TagContainer::NoTag(&self.1).serialize(serializer),
         }
     }
 }

--- a/minicbor-serde/src/tag.rs
+++ b/minicbor-serde/src/tag.rs
@@ -1,0 +1,128 @@
+//!  Module providing types to support custom tags in CBOR
+use core::ops::{Deref, DerefMut};
+use minicbor::data::Tag;
+
+/// Requires unique tag to be present during deserialization
+///
+/// Tags will always be emitted during serialization
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Required<const TAG: u64, T>(T);
+
+impl<const TAG: u64, T> Required<TAG, T> {
+    const EXPECTED_TAG: Tag = Tag::new(TAG);
+
+    /// Creates a new tagged [`Required`]
+    pub const fn new(val: T) -> Self {
+        Self(val)
+    }
+
+    /// Returns the associated tag
+    pub const fn tag(&self) -> Tag {
+        Self::EXPECTED_TAG
+    }
+
+    /// Returns the inner value, while consuming self
+    pub fn into_value(self) -> T {
+        self.0
+    }
+}
+
+impl<const TAG: u64, T> Deref for Required<TAG, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const TAG: u64, T> DerefMut for Required<TAG, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Accepts an unique tag during deserialization, if present
+///
+/// Tag will be emitted during serialization, if present
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Optional<const TAG: u64, T>(Option<Tag>, T);
+
+impl<const TAG: u64, T> Optional<TAG, T> {
+    const EXPECTED_TAG: Tag = Tag::new(TAG);
+
+    /// Creates a new tagged [`Optional`]
+    pub const fn tagged(val: T) -> Self {
+        Self(Some(Self::EXPECTED_TAG), val)
+    }
+
+    /// Creates a new untagged [`Optional`]
+    pub const fn untagged(val: T) -> Self {
+        Self(None, val)
+    }
+
+    /// Returns the associated tag (if any)
+    pub const fn tag(&self) -> Option<Tag> {
+        self.0
+    }
+
+    /// Returns the inner value, while consuming self
+    pub fn into_value(self) -> T {
+        self.1
+    }
+}
+
+impl<const TAG: u64, T> Deref for Optional<TAG, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.1
+    }
+}
+
+impl<const TAG: u64, T> DerefMut for Optional<TAG, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.1
+    }
+}
+
+/// Accepts any tag during deserialization, if present
+///
+/// Tag will be emitted during serialization, if present
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Any<T>(Option<Tag>, T);
+
+impl<T> Any<T> {
+    /// Creates a new tagged [`Any`]
+    pub fn tagged<N: Into<Tag>>(tag: N, val: T) -> Self {
+        Self(Some(tag.into()), val)
+    }
+
+    /// Creates a new untagged [`Any`]
+    pub const fn untagged(val: T) -> Self {
+        Self(None, val)
+    }
+
+    /// Returns the associated tag (if any)
+    pub const fn tag(&self) -> Option<Tag> {
+        self.0
+    }
+
+    /// Returns the inner value, while consuming self
+    pub fn into_value(self) -> T {
+        self.1
+    }
+}
+
+impl<T> Deref for Any<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.1
+    }
+}
+
+impl<T> DerefMut for Any<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.1
+    }
+}

--- a/minicbor-serde/src/tag.rs
+++ b/minicbor-serde/src/tag.rs
@@ -1,6 +1,140 @@
 //!  Module providing types to support custom tags in CBOR
 use core::ops::{Deref, DerefMut};
 use minicbor::data::Tag;
+use serde::{Deserialize, de};
+
+/// Enum alias for [`TagContainer`]
+pub(crate) const TAG_CONTAINER_IDENTIFIER: &str = "$#minicbor_serde_tag_container#$";
+
+/// Variant alias for [`TagContainer::Tag`]
+pub(crate) const TAG_IDENTIFIER: &str = "$#minicbor_serde_tag#$";
+
+/// Variant alias for [`TagContainer::NoTag`]
+pub(crate) const NO_TAG_IDENTIFIER: &str = "$#minicbor_serde_no_tag#$";
+
+/// Enum used to guide [`crate::de::Deserializer`] to deserialize a tagged
+/// value.
+///
+/// [`de::Deserialize`] implementation for this enum renames the fields to
+/// custom aliases to ensure that [`crate::de::Deserializer`] is able to drive
+/// the [`minicbor::Decoder`] correctly.
+enum TagContainer<T> {
+    Tag(Tag, T),
+    NoTag(T),
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for TagContainer<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_enum(
+            TAG_CONTAINER_IDENTIFIER,
+            &[TAG_IDENTIFIER, NO_TAG_IDENTIFIER],
+            TagContainerVisitor(core::marker::PhantomData),
+        )
+    }
+}
+
+struct TagContainerVisitor<T>(core::marker::PhantomData<T>);
+
+impl<'de, T: Deserialize<'de>> de::Visitor<'de> for TagContainerVisitor<T> {
+    type Value = TagContainer<T>;
+
+    fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "enum TagContainer")
+    }
+
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        use de::VariantAccess;
+        let (variant, access) = data.variant::<&str>()?;
+        match variant {
+            TAG_IDENTIFIER => {
+                let (tag, val) =
+                    access.tuple_variant(2, TupleVisitor(core::marker::PhantomData))?;
+                Ok(TagContainer::Tag(Tag::new(tag), val))
+            }
+            NO_TAG_IDENTIFIER => {
+                let val = access.newtype_variant()?;
+                Ok(TagContainer::NoTag(val))
+            }
+            _ => Err(de::Error::unknown_variant(
+                variant,
+                &[TAG_IDENTIFIER, NO_TAG_IDENTIFIER],
+            )),
+        }
+    }
+}
+
+struct TupleVisitor<T>(core::marker::PhantomData<T>);
+
+impl<'de, T: Deserialize<'de>> de::Visitor<'de> for TupleVisitor<T> {
+    type Value = (u64, T);
+
+    fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "tuple (u64, T)")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let tag = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+        let val = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+        Ok((tag, val))
+    }
+}
+
+/// Helper struct for formatting tag mismatch errors
+struct TagMismatchError {
+    found: Tag,
+    expected: Tag,
+}
+
+impl TagMismatchError {
+    fn new<A: Into<Tag>, B: Into<Tag>>(found: A, expected: B) -> Self {
+        Self {
+            found: found.into(),
+            expected: expected.into(),
+        }
+    }
+}
+
+impl core::fmt::Display for TagMismatchError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(
+            f,
+            "unexpected CBOR tag {}, expected {}",
+            self.found, self.expected
+        )
+    }
+}
+
+/// Helper struct for formatting expected tag errors
+struct ExpectedTagError {
+    expected: Tag,
+}
+
+impl ExpectedTagError {
+    fn new<A: Into<Tag>>(expected: A) -> Self {
+        Self {
+            expected: expected.into(),
+        }
+    }
+}
+
+impl core::fmt::Display for ExpectedTagError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "expected CBOR tag {}", self.expected)
+    }
+}
 
 /// Requires unique tag to be present during deserialization
 ///
@@ -38,6 +172,23 @@ impl<const TAG: u64, T> Deref for Required<TAG, T> {
 impl<const TAG: u64, T> DerefMut for Required<TAG, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl<'de, const TAG: u64, T: Deserialize<'de>> Deserialize<'de> for Required<TAG, T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let container = TagContainer::deserialize(deserializer)?;
+        match container {
+            TagContainer::Tag(tag, val) if tag == Self::EXPECTED_TAG => Ok(Required(val)),
+            TagContainer::Tag(tag, _) => Err(de::Error::custom(TagMismatchError::new(
+                tag,
+                Self::EXPECTED_TAG,
+            ))),
+            _ => Err(de::Error::custom(ExpectedTagError::new(Self::EXPECTED_TAG))),
+        }
     }
 }
 
@@ -85,6 +236,25 @@ impl<const TAG: u64, T> DerefMut for Optional<TAG, T> {
     }
 }
 
+impl<'de, const TAG: u64, T: Deserialize<'de>> Deserialize<'de> for Optional<TAG, T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let container = TagContainer::deserialize(deserializer)?;
+        match container {
+            TagContainer::Tag(tag, val) if tag == Self::EXPECTED_TAG => {
+                Ok(Optional(Some(tag), val))
+            }
+            TagContainer::NoTag(val) => Ok(Optional(None, val)),
+            TagContainer::Tag(tag, _) => Err(de::Error::custom(TagMismatchError::new(
+                tag,
+                Self::EXPECTED_TAG,
+            ))),
+        }
+    }
+}
+
 /// Accepts any tag during deserialization, if present
 ///
 /// Tag will be emitted during serialization, if present
@@ -124,5 +294,18 @@ impl<T> Deref for Any<T> {
 impl<T> DerefMut for Any<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.1
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Any<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let container = TagContainer::deserialize(deserializer)?;
+        match container {
+            TagContainer::Tag(tag, val) => Ok(Any(Some(tag), val)),
+            TagContainer::NoTag(val) => Ok(Any(None, val)),
+        }
     }
 }

--- a/minicbor-tests/Cargo.toml
+++ b/minicbor-tests/Cargo.toml
@@ -21,5 +21,6 @@ rand      = "0.9.0"
 half       = "2.4.1"
 hex        = "0.4.2"
 quickcheck = "1.0.1"
+minicbor-serde = { path = "../minicbor-serde", features = ["alloc"] }
 serde      = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11"

--- a/minicbor-tests/tests/tag_interop.rs
+++ b/minicbor-tests/tests/tag_interop.rs
@@ -1,0 +1,100 @@
+use minicbor::data::{Tag, Tagged};
+use minicbor_serde::tag::{Any, Optional, Required};
+
+const TEST_TAG: u64 = 42;
+const TEST_TAG2: u64 = 20;
+
+#[test]
+fn minicbor_to_serde_required() {
+    let value = Tagged::<TEST_TAG, u32>::new(123);
+    let bytes = minicbor::to_vec(&value).unwrap();
+    let decoded: Required<TEST_TAG, u32> = minicbor_serde::from_slice(&bytes).unwrap();
+    assert_eq!(decoded.into_value(), 123);
+}
+
+#[test]
+fn minicbor_to_serde_optional_with_tag() {
+    let value = Tagged::<TEST_TAG, String>::new("hello".to_string());
+    let bytes = minicbor::to_vec(&value).unwrap();
+    let decoded: Optional<TEST_TAG, String> = minicbor_serde::from_slice(&bytes).unwrap();
+    assert_eq!(decoded.tag().map(Tag::as_u64), Some(TEST_TAG));
+    assert_eq!(decoded.into_value(), "hello");
+}
+
+#[test]
+fn minicbor_to_serde_any_with_tag() {
+    let value = Tagged::<TEST_TAG, bool>::new(true);
+    let bytes = minicbor::to_vec(&value).unwrap();
+    let decoded: Any<bool> = minicbor_serde::from_slice(&bytes).unwrap();
+    assert_eq!(decoded.tag().map(Tag::as_u64), Some(TEST_TAG));
+    assert_eq!(decoded.into_value(), true);
+}
+
+#[test]
+fn minicbor_untagged_to_serde_optional() {
+    let value = 456u32;
+    let bytes = minicbor::to_vec(&value).unwrap();
+    let decoded: Optional<TEST_TAG, u32> = minicbor_serde::from_slice(&bytes).unwrap();
+    assert_eq!(decoded.tag().map(Tag::as_u64), None);
+    assert_eq!(decoded.into_value(), 456);
+}
+
+#[test]
+fn minicbor_untagged_to_serde_any() {
+    let value = "test".to_string();
+    let bytes = minicbor::to_vec(&value).unwrap();
+    let decoded: Any<String> = minicbor_serde::from_slice(&bytes).unwrap();
+    assert_eq!(decoded.tag().map(Tag::as_u64), None);
+    assert_eq!(decoded.into_value(), "test");
+}
+
+#[test]
+fn minicbor_wrong_tag_to_serde_required_fails() {
+    let value = Tagged::<TEST_TAG, u32>::new(42);
+    let bytes = minicbor::to_vec(&value).unwrap();
+    let result = minicbor_serde::from_slice::<Required<TEST_TAG2, u32>>(&bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn serde_required_to_minicbor() {
+    let value = Required::<TEST_TAG, u32>::new(123);
+    let bytes = minicbor_serde::to_vec(&value).unwrap();
+    let decoded: Tagged<TEST_TAG, u32> = minicbor::decode(&bytes).unwrap();
+    assert_eq!(decoded.tag().as_u64(), TEST_TAG);
+    assert_eq!(*decoded.value(), 123);
+}
+
+#[test]
+fn serde_optional_with_tag_to_minicbor() {
+    let value = Optional::<TEST_TAG, String>::tagged("hello".to_string());
+    let bytes = minicbor_serde::to_vec(&value).unwrap();
+    let decoded: Tagged<TEST_TAG, String> = minicbor::decode(&bytes).unwrap();
+    assert_eq!(decoded.tag().as_u64(), TEST_TAG);
+    assert_eq!(*decoded.value(), "hello");
+}
+
+#[test]
+fn serde_optional_without_tag_to_minicbor() {
+    let value = Optional::<TEST_TAG, u32>::untagged(456);
+    let bytes = minicbor_serde::to_vec(&value).unwrap();
+    let decoded: u32 = minicbor::decode(&bytes).unwrap();
+    assert_eq!(decoded, 456);
+}
+
+#[test]
+fn serde_any_with_tag_to_minicbor() {
+    let value = Any::tagged(Tag::new(TEST_TAG), true);
+    let bytes = minicbor_serde::to_vec(&value).unwrap();
+    let decoded: Tagged<TEST_TAG, bool> = minicbor::decode(&bytes).unwrap();
+    assert_eq!(decoded.tag().as_u64(), TEST_TAG);
+    assert_eq!(*decoded.value(), true);
+}
+
+#[test]
+fn serde_any_without_tag_to_minicbor() {
+    let value = Any::untagged("test".to_string());
+    let bytes = minicbor_serde::to_vec(&value).unwrap();
+    let decoded: String = minicbor::decode(&bytes).unwrap();
+    assert_eq!(decoded, "test");
+}


### PR DESCRIPTION
Patch series adds support to deserialize / serialize custom tags in minicbor-serde. 

See #44 for more details