### PR TITLE
Add MaxCborLen trait and derive macro for compile-time max CBOR size

### DIFF
--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -533,6 +533,7 @@ extern crate proc_macro;
 mod decode;
 mod encode;
 mod cbor_len;
+mod max_cbor_len;
 
 pub(crate) mod attrs;
 pub(crate) mod fields;
@@ -571,6 +572,18 @@ enum Mode {
 #[proc_macro_derive(CborLen, attributes(n, b, cbor))]
 pub fn derive_cbor_len(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     cbor_len::derive_from(input)
+}
+
+/// Derive the `minicbor::MaxCborLen` trait for a struct or enum.
+///
+/// Computes the maximum possible CBOR encoding length as a compile-time constant.
+/// This is useful for allocating fixed-size buffers in `no_std` environments
+/// without `alloc`. All field types must also implement `MaxCborLen`.
+///
+/// See the [crate] documentation for details.
+#[proc_macro_derive(MaxCborLen, attributes(n, b, cbor))]
+pub fn derive_max_cbor_len(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    max_cbor_len::derive_from(input)
 }
 
 // Helpers ////////////////////////////////////////////////////////////////////

--- a/minicbor-derive/src/max_cbor_len.rs
+++ b/minicbor-derive/src/max_cbor_len.rs
@@ -1,0 +1,210 @@
+use quote::quote;
+use syn::spanned::Spanned;
+
+use crate::attrs::{Attributes, Encoding, Level};
+use crate::collect_type_params;
+use crate::fields::Fields;
+use crate::variants::Variants;
+
+/// Entry point to derive `minicbor::MaxCborLen` on structs and enums.
+///
+/// This reuses the same field/variant/attribute infrastructure as `CborLen`,
+/// but generates compile-time const expressions instead of runtime code.
+/// The const helper fns `unsigned_cbor_len` and `signed_cbor_len` serve as
+/// the const-compatible counterparts to `CborLen` impls for headers and indices.
+pub fn derive_from(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let mut input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let result = match &input.data {
+        syn::Data::Struct(_) => on_struct(&mut input),
+        syn::Data::Enum(_) => on_enum(&mut input),
+        syn::Data::Union(u) => Err(syn::Error::new(
+            u.union_token.span(),
+            "deriving `minicbor::MaxCborLen` for a `union` is not supported",
+        )),
+    };
+    proc_macro::TokenStream::from(result.unwrap_or_else(|e| e.to_compile_error()))
+}
+
+fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let data = if let syn::Data::Struct(d) = &inp.data {
+        d
+    } else {
+        unreachable!()
+    };
+
+    let name = inp.ident.clone();
+    let attrs = Attributes::try_from_iter(Level::Struct, inp.attrs.iter())?;
+    let fields = Fields::try_from(name.span(), data.fields.iter(), &[&attrs])?;
+
+    add_bounds(&mut inp.generics, &fields);
+    let (ig, tg, wc) = inp.generics.split_for_impl();
+
+    if attrs.transparent() {
+        if fields.fields().len() != 1 {
+            return Err(syn::Error::new(
+                name.span(),
+                "#[cbor(transparent)] requires exactly one field",
+            ));
+        }
+        let ty = &fields.fields().next().unwrap().typ;
+        return Ok(quote! {
+            impl #ig minicbor::MaxCborLen for #name #tg #wc {
+                const MAX_CBOR_LEN: usize = <#ty as minicbor::MaxCborLen>::MAX_CBOR_LEN;
+            }
+        });
+    }
+
+    let tag = tag_size(&attrs);
+    let body = fields_size(&fields, attrs.encoding().unwrap_or_default())?;
+
+    Ok(quote! {
+        impl #ig minicbor::MaxCborLen for #name #tg #wc {
+            const MAX_CBOR_LEN: usize = #tag + #body;
+        }
+    })
+}
+
+fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let data = if let syn::Data::Enum(d) = &inp.data {
+        d
+    } else {
+        unreachable!()
+    };
+
+    let name = inp.ident.clone();
+    let enum_attrs = Attributes::try_from_iter(Level::Enum, inp.attrs.iter())?;
+    let encoding = enum_attrs.encoding().unwrap_or_default();
+    let index_only = enum_attrs.index_only();
+    let flat = enum_attrs.flat();
+    let variants = Variants::try_from(name.span(), data.variants.iter(), &enum_attrs)?;
+
+    let mut all_fields = Vec::new();
+    let mut sizes = Vec::new();
+
+    for ((var, idx), va) in data
+        .variants
+        .iter()
+        .zip(&variants.indices)
+        .zip(&variants.attrs)
+    {
+        let fields = Fields::try_from(var.ident.span(), var.fields.iter(), &[va, &enum_attrs])?;
+        all_fields.extend(fields.fields().cloned());
+        let iv = idx.val();
+        let tag = tag_size(va);
+        let enc = va.encoding().unwrap_or(encoding);
+
+        let size = match &var.fields {
+            syn::Fields::Unit if index_only => quote! { minicbor::encode::signed_cbor_len(#iv) },
+            syn::Fields::Unit if flat => quote! { 1 + minicbor::encode::signed_cbor_len(#iv) },
+            syn::Fields::Unit => quote! { 1 + minicbor::encode::signed_cbor_len(#iv) + #tag + 1 },
+            _ if index_only => {
+                return Err(syn::Error::new(
+                    var.ident.span(),
+                    "index_only enums must not have fields",
+                ));
+            }
+            _ => {
+                let body = fields_size(&fields, enc)?;
+                if flat {
+                    quote! { #body + minicbor::encode::signed_cbor_len(#iv) }
+                } else {
+                    quote! { #body + #tag + 1 + minicbor::encode::signed_cbor_len(#iv) }
+                }
+            }
+        };
+        sizes.push(size);
+    }
+
+    let bound: syn::TypeParamBound = syn::parse_quote!(minicbor::MaxCborLen);
+    let used = collect_type_params(&inp.generics, all_fields.iter());
+    for p in inp.generics.type_params_mut() {
+        if used.contains(&p.ident) && !p.bounds.iter().any(|b| *b == bound) {
+            p.bounds.push(bound.clone());
+        }
+    }
+    let (ig, tg, wc) = inp.generics.split_for_impl();
+    let tag = tag_size(&enum_attrs);
+
+    let body = sizes
+        .into_iter()
+        .rev()
+        .reduce(|acc, v| quote! { minicbor::encode::const_max(#v, #acc) })
+        .unwrap_or_else(|| quote!(0));
+
+    Ok(quote! {
+        impl #ig minicbor::MaxCborLen for #name #tg #wc {
+            const MAX_CBOR_LEN: usize = #tag + #body;
+        }
+    })
+}
+
+/// Compute const expression for max encoded size of a field set.
+///
+/// Uses `<T as MaxCborLen>::MAX_CBOR_LEN` per field — the const analogue of
+/// `CborLen::cbor_len()` — and `unsigned_cbor_len`/`signed_cbor_len` for
+/// headers and index keys (the const analogues of the runtime CborLen impls
+/// for integers).
+fn fields_size(fields: &Fields, encoding: Encoding) -> syn::Result<proc_macro2::TokenStream> {
+    let active: Vec<_> = fields.fields().collect();
+
+    match encoding {
+        Encoding::Map => {
+            let n = active.len();
+            let mut parts = vec![quote! { minicbor::encode::unsigned_cbor_len(#n as u64) }];
+            for f in &active {
+                let ty = &f.typ;
+                let iv = f.index.val();
+                let tag = tag_size(&f.attrs);
+                parts.push(quote! {
+                    minicbor::encode::signed_cbor_len(#iv) + #tag
+                        + <#ty as minicbor::MaxCborLen>::MAX_CBOR_LEN
+                });
+            }
+            Ok(quote! { #(#parts)+* })
+        }
+        Encoding::Array => {
+            if active.is_empty() {
+                return Ok(quote!(1));
+            }
+            let max_idx = active.iter().map(|f| f.index.val()).max().unwrap();
+            let array_len = (max_idx + 1) as u64;
+            let mut parts = vec![quote! { minicbor::encode::unsigned_cbor_len(#array_len) }];
+            let mut sorted: Vec<_> = active.iter().map(|f| (f.index.val(), *f)).collect();
+            sorted.sort_by_key(|(i, _)| *i);
+            let mut prev = 0i64;
+            for (idx, f) in sorted {
+                let gap = (idx - prev) as usize;
+                if gap > 0 {
+                    parts.push(quote!(#gap));
+                }
+                let ty = &f.typ;
+                let tag = tag_size(&f.attrs);
+                parts.push(quote! { #tag + <#ty as minicbor::MaxCborLen>::MAX_CBOR_LEN });
+                prev = idx + 1;
+            }
+            Ok(quote! { #(#parts)+* })
+        }
+    }
+}
+
+fn tag_size(a: &Attributes) -> proc_macro2::TokenStream {
+    if let Some(t) = a.tag() {
+        quote!(minicbor::encode::unsigned_cbor_len(#t))
+    } else {
+        quote!(0)
+    }
+}
+
+/// Add `MaxCborLen` bounds to type params appearing in the given fields.
+///
+/// Reuses `collect_type_params` from the crate root to find which type
+/// parameters appear in the field types, then adds the bound.
+fn add_bounds(generics: &mut syn::Generics, fields: &Fields) {
+    let used = collect_type_params(generics, fields.fields());
+    let bound: syn::TypeParamBound = syn::parse_quote!(minicbor::MaxCborLen);
+    for p in generics.type_params_mut() {
+        if used.contains(&p.ident) && !p.bounds.iter().any(|b| *b == bound) {
+            p.bounds.push(bound.clone());
+        }
+    }
+}

--- a/minicbor-tests/tests/max_cbor_len.rs
+++ b/minicbor-tests/tests/max_cbor_len.rs
@@ -1,0 +1,295 @@
+use minicbor::{Encode, CborLen, MaxCborLen};
+
+// --- Structs ---
+
+#[derive(Encode, CborLen, MaxCborLen)]
+#[cbor(array)]
+struct SimpleArray {
+    #[n(0)] x: u8,
+    #[n(1)] y: u32,
+    #[n(2)] z: bool,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(map)]
+struct SimpleMap {
+    #[n(0)] x: u8,
+    #[n(1)] y: u32,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(transparent)]
+struct Transparent(#[n(0)] u32);
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct WithOption {
+    #[n(0)] a: u8,
+    #[n(1)] b: Option<u32>,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct WithGap {
+    #[n(0)] a: u8,
+    #[n(3)] b: u32,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct Nested {
+    #[n(0)] inner: SimpleArray,
+    #[n(1)] val: u8,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct WithArray {
+    #[n(0)] id: u8,
+    #[n(1)] data: [u32; 3],
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct TupleStruct(#[n(0)] u8, #[n(1)] u32);
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct Tagged {
+    #[n(0)] #[cbor(tag(1))] x: u32,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct WithSkip {
+    #[n(0)] a: u8,
+    #[cbor(skip)] #[allow(dead_code)] b: u32,
+    #[n(1)] c: bool,
+}
+
+// --- Enums ---
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(index_only)]
+#[allow(dead_code)]
+enum IndexOnly {
+    #[n(0)] A,
+    #[n(1)] B,
+    #[n(2)] C,
+}
+
+#[derive(Encode, MaxCborLen)]
+#[allow(dead_code)]
+enum WithFields {
+    #[n(0)] Unit,
+    #[n(1)] One { #[n(0)] x: u8 },
+    #[n(2)] Two { #[n(0)] a: u32, #[n(1)] b: bool },
+}
+
+#[derive(Encode, MaxCborLen)]
+#[allow(dead_code)]
+enum WithTupleVariant {
+    #[n(0)] A,
+    #[n(1)] B(#[n(0)] u8, #[n(1)] u32),
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(flat)]
+#[allow(dead_code)]
+enum Flat {
+    #[n(0)] A,
+    #[n(1)] B(#[n(0)] u8, #[n(1)] u32),
+}
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(map)]
+#[allow(dead_code)]
+enum MapEnum {
+    #[n(0)] X { #[n(0)] a: u8 },
+    #[n(1)] Y { #[n(0)] a: u32, #[n(1)] b: bool },
+}
+
+// --- Generic ---
+
+#[derive(Encode, MaxCborLen)]
+#[cbor(array)]
+struct GenericStruct<T> {
+    #[n(0)] val: T,
+}
+
+// --- Tests ---
+
+#[test]
+fn primitive_max_sizes() {
+    assert_eq!(bool::MAX_CBOR_LEN, 1);
+    assert_eq!(u8::MAX_CBOR_LEN, 2);
+    assert_eq!(u16::MAX_CBOR_LEN, 3);
+    assert_eq!(u32::MAX_CBOR_LEN, 5);
+    assert_eq!(u64::MAX_CBOR_LEN, 9);
+    assert_eq!(i8::MAX_CBOR_LEN, 2);
+    assert_eq!(i16::MAX_CBOR_LEN, 3);
+    assert_eq!(i32::MAX_CBOR_LEN, 5);
+    assert_eq!(i64::MAX_CBOR_LEN, 9);
+    assert_eq!(f32::MAX_CBOR_LEN, 5);
+    assert_eq!(f64::MAX_CBOR_LEN, 9);
+}
+
+#[test]
+fn simple_array_struct() {
+    // array(3) header = 1, u8 max = 2, u32 max = 5, bool = 1 => 1 + 2 + 5 + 1 = 9
+    assert_eq!(SimpleArray::MAX_CBOR_LEN, 9);
+}
+
+#[test]
+fn simple_map_struct() {
+    // map(2) header = 1
+    // field 0: index 0 key = 1, u8 max = 2  => 3
+    // field 1: index 1 key = 1, u32 max = 5 => 6
+    // total = 1 + 3 + 6 = 10
+    assert_eq!(SimpleMap::MAX_CBOR_LEN, 10);
+}
+
+#[test]
+fn transparent_struct() {
+    assert_eq!(Transparent::MAX_CBOR_LEN, u32::MAX_CBOR_LEN);
+}
+
+#[test]
+fn option_field() {
+    // array(2) = 1, u8 max = 2, Option<u32> max = max(1, 5) = 5
+    // total = 1 + 2 + 5 = 8
+    assert_eq!(WithOption::MAX_CBOR_LEN, 8);
+}
+
+#[test]
+fn gap_in_indices() {
+    // Fields at indices 0 and 3.
+    // array(4) header = 1, field 0: u8 = 2, gaps at 1,2 = 2 nulls, field 3: u32 = 5
+    // total = 1 + 2 + 2 + 5 = 10
+    assert_eq!(WithGap::MAX_CBOR_LEN, 10);
+}
+
+#[test]
+fn nested_struct() {
+    // array(2) = 1, SimpleArray::MAX = 9, u8 = 2 => 12
+    assert_eq!(Nested::MAX_CBOR_LEN, 12);
+}
+
+#[test]
+fn index_only_enum() {
+    // max index value cbor_len: indices 0,1,2 all fit in 1 byte
+    assert_eq!(IndexOnly::MAX_CBOR_LEN, 1);
+}
+
+#[test]
+fn enum_with_fields() {
+    // Variant 0 (Unit): 1 (array(2)) + 1 (idx 0) + 0 (tag) + 1 (empty array body for unit)
+    //   = 3
+    // Variant 1 (One {x: u8}): 1 + 1 + 0 + array(1)=1 + u8=2 = 5
+    // Variant 2 (Two {a: u32, b: bool}): 1 + 1 + 0 + array(2)=1 + u32=5 + bool=1 = 9
+    // Max = 9
+    assert_eq!(WithFields::MAX_CBOR_LEN, 9);
+}
+
+#[test]
+fn flat_enum() {
+    // Variant A: 1 (array header for len 1) + 1 (idx 0) = 2
+    // Variant B: 1 (array header of 3 elements) + u8=2 + u32=5 + 1 (idx 1) = 9
+    // Max = 9
+    assert_eq!(Flat::MAX_CBOR_LEN, 9);
+}
+
+#[test]
+fn generic_struct() {
+    assert_eq!(<GenericStruct<u8>>::MAX_CBOR_LEN, 1 + 2); // array(1) + u8
+    assert_eq!(<GenericStruct<u64>>::MAX_CBOR_LEN, 1 + 9); // array(1) + u64
+}
+
+#[test]
+fn encoding_fits_in_max() {
+    // Encode some values and check the actual encoded size is <= MAX_CBOR_LEN
+    let val = SimpleArray { x: 255, y: 0xFFFF_FFFF, z: true };
+    let mut buf = [0u8; 128];
+    let len = minicbor::encode(&val, buf.as_mut_slice()).map(|_| {
+        minicbor::encode::CborLen::<()>::cbor_len(&val, &mut ())
+    }).unwrap();
+    assert!(len <= SimpleArray::MAX_CBOR_LEN, "actual {len} > max {}", SimpleArray::MAX_CBOR_LEN);
+
+    // Also with smaller values
+    let val = SimpleArray { x: 0, y: 0, z: false };
+    let len = minicbor::encode::CborLen::<()>::cbor_len(&val, &mut ());
+    assert!(len <= SimpleArray::MAX_CBOR_LEN);
+}
+
+#[test]
+fn array_max_size() {
+    // [u8; 4]: header for 4 = 1, 4 * 2 = 8. Total = 9
+    assert_eq!(<[u8; 4]>::MAX_CBOR_LEN, 9);
+}
+
+#[test]
+fn tuple_max_size() {
+    // (u8, u32): header for 2 = 1, u8 = 2, u32 = 5. Total = 8
+    assert_eq!(<(u8, u32)>::MAX_CBOR_LEN, 8);
+}
+
+#[test]
+fn struct_with_array_field() {
+    // array(2) = 1, u8 = 2, [u32; 3] = 1 (array header) + 3*5 = 16
+    // total = 1 + 2 + 16 = 19
+    assert_eq!(WithArray::MAX_CBOR_LEN, 19);
+}
+
+#[test]
+fn tuple_struct() {
+    // array(2) = 1, u8 = 2, u32 = 5. Total = 8
+    assert_eq!(TupleStruct::MAX_CBOR_LEN, 8);
+}
+
+#[test]
+fn tagged_field() {
+    // array(1) = 1, tag(1) = 1, u32 = 5. Total = 7
+    assert_eq!(Tagged::MAX_CBOR_LEN, 7);
+}
+
+#[test]
+fn skipped_field() {
+    // Skipped fields don't contribute to encoded size.
+    // array(2) = 1, u8 = 2, bool = 1. Total = 4
+    assert_eq!(WithSkip::MAX_CBOR_LEN, 4);
+}
+
+#[test]
+fn enum_with_tuple_variant() {
+    // Variant A (Unit): 1 (array(2)) + 1 (idx) + 1 (empty body) = 3
+    // Variant B: 1 (array(2)) + 1 (idx) + array(2)=1 + u8=2 + u32=5 = 10
+    // Max = 10
+    assert_eq!(WithTupleVariant::MAX_CBOR_LEN, 10);
+}
+
+#[test]
+fn map_encoded_enum() {
+    // Variant X: 1 (array(2)) + 1 (idx) + map(1)=1 + (idx0=1 + u8=2) = 6
+    // Variant Y: 1 (array(2)) + 1 (idx) + map(2)=1 + (idx0=1 + u32=5) + (idx1=1 + bool=1) = 11
+    // Max = 11
+    assert_eq!(MapEnum::MAX_CBOR_LEN, 11);
+}
+
+#[test]
+fn nonzero_max_size() {
+    assert_eq!(core::num::NonZeroU8::MAX_CBOR_LEN, u8::MAX_CBOR_LEN);
+    assert_eq!(core::num::NonZeroU32::MAX_CBOR_LEN, u32::MAX_CBOR_LEN);
+    assert_eq!(core::num::NonZeroI64::MAX_CBOR_LEN, i64::MAX_CBOR_LEN);
+}
+
+#[test]
+fn result_max_size() {
+    // array(2) + discriminant(1) + max(u8=2, u32=5) = 1 + 1 + 5 = 7
+    assert_eq!(<Result<u8, u32>>::MAX_CBOR_LEN, 7);
+}
+
+#[test]
+fn duration_max_size() {
+    // array(2) + u64=9 + u32=5 = 1 + 9 + 5 = 15
+    assert_eq!(core::time::Duration::MAX_CBOR_LEN, 15);
+}

--- a/minicbor/src/encode.rs
+++ b/minicbor/src/encode.rs
@@ -54,6 +54,51 @@ pub trait CborLen<C> {
     fn cbor_len(&self, ctx: &mut C) -> usize;
 }
 
+/// A type whose maximum CBOR encoding length is known at compile time.
+///
+/// This is useful for allocating fixed-size buffers in `no_std` environments
+/// without `alloc`.
+///
+/// # Example
+///
+/// ```
+/// use minicbor::encode::MaxCborLen;
+///
+/// fn send<T: minicbor::Encode<()> + MaxCborLen>(val: T) {
+///     let mut buf = [0u8; T::MAX_CBOR_LEN];
+///     minicbor::encode(val, buf.as_mut_slice()).unwrap();
+/// }
+/// ```
+pub trait MaxCborLen {
+    /// The maximum number of bytes the CBOR encoding of this type can produce.
+    const MAX_CBOR_LEN: usize;
+}
+
+/// Computes the CBOR encoded length of an unsigned integer value at compile time.
+///
+/// Useful for computing array/map header sizes and index key sizes as constants.
+pub const fn unsigned_cbor_len(n: u64) -> usize {
+    if n <= 0x17 { 1 }
+    else if n <= 0xff { 2 }
+    else if n <= 0xffff { 3 }
+    else if n <= 0xffff_ffff { 5 }
+    else { 9 }
+}
+
+/// Computes the CBOR encoded length of a signed integer value at compile time.
+pub const fn signed_cbor_len(n: i64) -> usize {
+    if n >= 0 {
+        unsigned_cbor_len(n as u64)
+    } else {
+        unsigned_cbor_len((-1 - n) as u64)
+    }
+}
+
+/// Returns the larger of two `usize` values. Usable in const contexts.
+pub const fn const_max(a: usize, b: usize) -> usize {
+    if a > b { a } else { b }
+}
+
 impl<C, T: Encode<C> + ?Sized> Encode<C> for &T {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
         (**self).encode(e, ctx)
@@ -587,6 +632,63 @@ impl<C> CborLen<C> for f64 {
     }
 }
 
+// --- MaxCborLen impls ---
+//
+// Uses unsigned_cbor_len / signed_cbor_len (the const equivalents of CborLen)
+// applied to worst-case values, so encoding size logic isn't duplicated.
+
+macro_rules! max_cbor_len {
+    (unsigned: $($t:ty),*) => {
+        $(impl MaxCborLen for $t {
+            const MAX_CBOR_LEN: usize = unsigned_cbor_len(<$t>::MAX as u64);
+        })*
+    };
+    (signed: $($t:ty),*) => {
+        $(impl MaxCborLen for $t {
+            const MAX_CBOR_LEN: usize = signed_cbor_len(<$t>::MIN as i64);
+        })*
+    };
+    (const: $($t:ty = $n:expr;)*) => {
+        $(impl MaxCborLen for $t { const MAX_CBOR_LEN: usize = $n; })*
+    };
+    (forward: $($t:ty => $inner:ty;)*) => {
+        $(impl MaxCborLen for $t {
+            const MAX_CBOR_LEN: usize = <$inner as MaxCborLen>::MAX_CBOR_LEN;
+        })*
+    };
+}
+
+// Integers: max cbor len = cbor len of worst-case value (no cfg needed — const evaluates per target)
+max_cbor_len!(unsigned: u8, u16, u32, u64, usize);
+max_cbor_len!(signed:   i8, i16, i32, i64, isize);
+max_cbor_len!(const: bool = 1; f32 = 5; f64 = 9; () = 1;);
+max_cbor_len!(forward:
+    core::num::NonZeroU8  => u8;  core::num::NonZeroU16 => u16;
+    core::num::NonZeroU32 => u32; core::num::NonZeroU64 => u64;
+    core::num::NonZeroI8  => i8;  core::num::NonZeroI16 => i16;
+    core::num::NonZeroI32 => i32; core::num::NonZeroI64 => i64;
+);
+#[cfg(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64"))]
+max_cbor_len!(forward: core::num::NonZeroUsize => usize; core::num::NonZeroIsize => isize;);
+
+impl MaxCborLen for char { const MAX_CBOR_LEN: usize = unsigned_cbor_len(char::MAX as u64); }
+impl<T> MaxCborLen for core::marker::PhantomData<T>   { const MAX_CBOR_LEN: usize = 1; }
+impl<T: MaxCborLen> MaxCborLen for core::num::Wrapping<T> { const MAX_CBOR_LEN: usize = T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::cell::Cell<T>    { const MAX_CBOR_LEN: usize = T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::cell::RefCell<T> { const MAX_CBOR_LEN: usize = T::MAX_CBOR_LEN; }
+
+impl<T: MaxCborLen> MaxCborLen for Option<T>                  { const MAX_CBOR_LEN: usize = const_max(1, T::MAX_CBOR_LEN); }
+impl<T: MaxCborLen, const N: usize> MaxCborLen for [T; N]     { const MAX_CBOR_LEN: usize = unsigned_cbor_len(N as u64) + N * T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen, E: MaxCborLen> MaxCborLen for Result<T, E> { const MAX_CBOR_LEN: usize = 1 + 1 + const_max(T::MAX_CBOR_LEN, E::MAX_CBOR_LEN); }
+impl MaxCborLen for core::time::Duration                       { const MAX_CBOR_LEN: usize = 1 + u64::MAX_CBOR_LEN + u32::MAX_CBOR_LEN; }
+
+impl<T: MaxCborLen> MaxCborLen for core::ops::Range<T>            { const MAX_CBOR_LEN: usize = 1 + 2 * T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::ops::RangeInclusive<T>   { const MAX_CBOR_LEN: usize = 1 + 2 * T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::ops::RangeFrom<T>        { const MAX_CBOR_LEN: usize = 1 + T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::ops::RangeTo<T>          { const MAX_CBOR_LEN: usize = 1 + T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::ops::RangeToInclusive<T> { const MAX_CBOR_LEN: usize = 1 + T::MAX_CBOR_LEN; }
+impl<T: MaxCborLen> MaxCborLen for core::ops::Bound<T>            { const MAX_CBOR_LEN: usize = 1 + 1 + const_max(T::MAX_CBOR_LEN, 1); }
+
 macro_rules! encode_nonzero {
     ($($t:ty)*) => {
         $(
@@ -744,6 +846,11 @@ macro_rules! encode_tuples {
                 fn cbor_len(&self, ctx: &mut Ctx) -> usize {
                     $len.cbor_len(ctx) $(+ self.$idx.cbor_len(ctx))+
                 }
+            }
+
+            impl<$($T: MaxCborLen),+> MaxCborLen for ($($T,)+) {
+                const MAX_CBOR_LEN: usize =
+                    unsigned_cbor_len($len) $(+ <$T as MaxCborLen>::MAX_CBOR_LEN)+;
             }
         )+
     }

--- a/minicbor/src/lib.rs
+++ b/minicbor/src/lib.rs
@@ -156,7 +156,7 @@ const SIMPLE: u8   = 0xe0;
 const BREAK: u8    = 0xff;
 
 pub use decode::{Decode, Decoder};
-pub use encode::{Encode, Encoder, CborLen};
+pub use encode::{Encode, Encoder, CborLen, MaxCborLen};
 
 #[cfg(feature = "derive")]
 pub use minicbor_derive::*;


### PR DESCRIPTION
## Add `MaxCborLen` trait and `#[derive(MaxCborLen)]`

Adds compile-time maximum CBOR encoding size calculation, useful for
fixed-size stack buffers in `no_std` without `alloc`:

```rust
#[derive(Encode, MaxCborLen)]
#[cbor(array)]
struct Msg {
    #[n(0)] sensor_id: u8,
    #[n(1)] reading: u32,
}

let mut buf = [0u8; Msg::MAX_CBOR_LEN];
minicbor::encode(&msg, buf.as_mut_slice()).unwrap();
```

