### PR TITLE
Add `#[cbor(crate = "...")]` to override the minicbor crate path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,6 +451,12 @@
 
 # minicbor-derive
 
+## Unreleased
+
+- Adds `#[cbor(crate = "<path>")]` to allow re-exporters of the derive macros to
+  point the generated code at a different path for the `minicbor` crate
+  (similar to serde's `#[serde(crate = "...")]`).
+
 ## `0.19.4`
 
 - Fixes `CborLen` related bugs, see commit 7d0b368cc92ca3be0acae5364461f5cae9df7cdd for details.

--- a/minicbor-derive/src/attrs.rs
+++ b/minicbor-derive/src/attrs.rs
@@ -46,7 +46,8 @@ pub enum Kind {
     Skip,
     SkipIf,
     Flat,
-    Default
+    Default,
+    Crate
 }
 
 #[derive(Debug, Clone)]
@@ -67,7 +68,8 @@ enum Value {
     Skip(proc_macro2::Span),
     SkipIf(Option<syn::ExprPath>, proc_macro2::Span),
     Flat(proc_macro2::Span),
-    Default(proc_macro2::Span)
+    Default(proc_macro2::Span),
+    Crate(syn::Path, proc_macro2::Span)
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -374,6 +376,9 @@ impl Attributes {
                 attrs.try_insert(Kind::Flat, Value::Flat(meta.path.span()))?
             } else if meta.path.is_ident("default") {
                 attrs.try_insert(Kind::Default, Value::Default(meta.path.span()))?
+            } else if meta.path.is_ident("crate") {
+                let s: LitStr = meta.value()?.parse()?;
+                attrs.try_insert(Kind::Crate, Value::Crate(s.parse()?, meta.path.span()))?
             } else {
                 return Err(meta.error("unsupported attribute"))
             }
@@ -443,6 +448,13 @@ impl Attributes {
         self.contains_key(Kind::Default)
     }
 
+    pub fn cbor_crate(&self) -> Option<&syn::Path> {
+        match self.get(Kind::Crate) {
+            Some(Value::Crate(p, _)) => Some(p),
+            _ => None
+        }
+    }
+
     fn contains_key(&self, k: Kind) -> bool {
         self.attrs.contains_key(&k)
     }
@@ -466,6 +478,7 @@ impl Attributes {
                 | Kind::Transparent
                 | Kind::ContextBound
                 | Kind::Tag
+                | Kind::Crate
                 => {}
                 | Kind::Borrow
                 | Kind::TypeParam
@@ -504,6 +517,7 @@ impl Attributes {
                 | Kind::Transparent
                 | Kind::ContextBound
                 | Kind::Flat
+                | Kind::Crate
                 => {
                     let msg = format!("attribute is not supported on {}-level", self.level);
                     return Err(syn::Error::new(val.span(), msg))
@@ -515,6 +529,7 @@ impl Attributes {
                 | Kind::ContextBound
                 | Kind::Tag
                 | Kind::Flat
+                | Kind::Crate
                 => {}
                 | Kind::Borrow
                 | Kind::TypeParam
@@ -552,6 +567,7 @@ impl Attributes {
                 | Kind::SkipIf
                 | Kind::Flat
                 | Kind::Default
+                | Kind::Crate
                 => {
                     let msg = format!("attribute is not supported on {}-level", self.level);
                     return Err(syn::Error::new(val.span(), msg))
@@ -728,7 +744,8 @@ impl Value {
             Value::Skip(s)            => *s,
             Value::SkipIf(_, s)       => *s,
             Value::Flat(s)            => *s,
-            Value::Default(s)         => *s
+            Value::Default(s)         => *s,
+            Value::Crate(_, s)        => *s
         }
     }
 

--- a/minicbor-derive/src/cbor_len.rs
+++ b/minicbor-derive/src/cbor_len.rs
@@ -57,13 +57,14 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             return Err(syn::Error::new(inp.ident.span(), msg))
         }
         let f = fields.fields().next().expect("struct has 1 field");
-        return make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)
+        let tokens = make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)?;
+        return Ok(crate::wrap_in_crate_alias(attrs.cbor_crate(), tokens))
     }
 
     let tag = on_tag(&attrs);
     let steps = on_fields(&fields, true, attrs.encoding().unwrap_or_default())?;
 
-    Ok(quote! {
+    Ok(crate::wrap_in_crate_alias(attrs.cbor_crate(), quote! {
         impl #impl_generics minicbor::CborLen<Ctx> for #name #typ_generics #where_clause {
             fn cbor_len(&self, __ctx777: &mut Ctx) -> usize {
                 #tag +
@@ -72,7 +73,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
                 }
             }
         }
-    })
+    }))
 }
 
 fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
@@ -182,7 +183,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 
     let tag = on_tag(&enum_attrs);
 
-    Ok(quote! {
+    Ok(crate::wrap_in_crate_alias(enum_attrs.cbor_crate(), quote! {
         impl #impl_generics minicbor::CborLen<Ctx> for #name #typ_generics #where_clause {
             fn cbor_len(&self, __ctx777: &mut Ctx) -> usize {
                 #tag +
@@ -191,7 +192,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
         }
-    })
+    }))
 }
 
 fn on_fields(fields: &Fields, has_self: bool, encoding: Encoding) -> syn::Result<Vec<proc_macro2::TokenStream>> {

--- a/minicbor-derive/src/decode.rs
+++ b/minicbor-derive/src/decode.rs
@@ -83,7 +83,8 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             return Err(syn::Error::new(inp.ident.span(), msg))
         }
         let f = fields.fields().next().expect("struct has 1 field");
-        return make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)
+        let tokens = make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)?;
+        return Ok(crate::wrap_in_crate_alias(attrs.cbor_crate(), tokens))
     }
 
     let statements = gen_statements(&fields, attrs.encoding().unwrap_or_default(), false)?;
@@ -120,7 +121,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
 
     let tag = decode_tag(&attrs);
 
-    Ok(quote! {
+    Ok(crate::wrap_in_crate_alias(attrs.cbor_crate(), quote! {
         impl #impl_generics minicbor::Decode<'bytes, Ctx> for #name #typ_generics #where_clause {
             fn decode(__d777: &mut minicbor::Decoder<'bytes>, __ctx777: &mut Ctx) -> core::result::Result<#name #typ_generics, minicbor::decode::Error> {
                 #tag
@@ -129,7 +130,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
                 #result
             }
         }
-    })
+    }))
 }
 
 /// Create a `Decode` impl for enums.
@@ -273,7 +274,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 
     let tag = decode_tag(&enum_attrs);
 
-    Ok(quote! {
+    Ok(crate::wrap_in_crate_alias(enum_attrs.cbor_crate(), quote! {
         impl #impl_generics minicbor::Decode<'bytes, Ctx> for #name #typ_generics #where_clause {
             fn decode(__d777: &mut minicbor::Decoder<'bytes>, __ctx777: &mut Ctx) -> core::result::Result<#name #typ_generics, minicbor::decode::Error> {
                 #tag
@@ -284,7 +285,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 }
             }
         }
-    })
+    }))
 }
 
 /// Generate decoding statements for every item.

--- a/minicbor-derive/src/encode.rs
+++ b/minicbor-derive/src/encode.rs
@@ -54,13 +54,14 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
             return Err(syn::Error::new(inp.ident.span(), msg))
         }
         let f = fields.fields().next().expect("struct has 1 field");
-        return make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)
+        let tokens = make_transparent_impl(&inp.ident, f, impl_generics, typ_generics, where_clause)?;
+        return Ok(crate::wrap_in_crate_alias(attrs.cbor_crate(), tokens))
     }
 
     let tag = encode_tag(&attrs);
     let (tests, statements) = encode_fields(&fields, true, encoding, false)?;
 
-    Ok(quote! {
+    Ok(crate::wrap_in_crate_alias(attrs.cbor_crate(), quote! {
         impl #impl_generics minicbor::Encode<Ctx> for #name #typ_generics #where_clause {
             fn encode<__W777>(&self, __e777: &mut minicbor::Encoder<__W777>, __ctx777: &mut Ctx) -> core::result::Result<(), minicbor::encode::Error<__W777::Error>>
             where
@@ -71,7 +72,7 @@ fn on_struct(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream
                 #statements
             }
         }
-    })
+    }))
 }
 
 /// Create an `Encode` impl for enums.
@@ -229,7 +230,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 
     let tag = encode_tag(&enum_attrs);
 
-    Ok(quote! {
+    Ok(crate::wrap_in_crate_alias(enum_attrs.cbor_crate(), quote! {
         impl #impl_generics minicbor::Encode<Ctx> for #name #typ_generics #where_clause {
             fn encode<__W777>(&self, __e777: &mut minicbor::Encoder<__W777>, __ctx777: &mut Ctx) -> core::result::Result<(), minicbor::encode::Error<__W777::Error>>
             where
@@ -239,7 +240,7 @@ fn on_enum(inp: &mut syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 #body
             }
         }
-    })
+    }))
 }
 
 /// The encoding logic of fields.

--- a/minicbor-derive/src/lib.rs
+++ b/minicbor-derive/src/lib.rs
@@ -109,6 +109,7 @@
 //! - [`#[cbor(bound)]`](#cborbound)
 //! - [`#[cbor(context_bound)]`](#cborcontext_bound--)
 //! - [`#[cbor(cbor_len)]`](#cborcbor_len--path)
+//! - [`#[cbor(crate = "...")]`](#cborcrate--path)
 //!
 //! ## `#[n(...)]` and `#[b(...)]` (or `#[cbor(n(...))]` and `#[cbor(b(...))]`)
 //!
@@ -317,6 +318,12 @@
 //! [`#[cbor(decode_bound = "...")]`](#cbordecode_bound--) and
 //! [`#[cbor(cbor_len_bound = "...")]`](#cborcbor_len_bound--), i.e. the bound applies
 //! to the derived `Encode`, `Decode` and `CborLen` impls.
+//!
+//! ## `#[cbor(crate = "<path>")]`
+//!
+//! On a struct or enum, overrides the path used by the derived impls to
+//! reach the `minicbor` crate. Useful for crates that re-export the derive
+//! macros from a different module path.
 //!
 //! ## `#[cbor(context_bound = "...")]`
 //!
@@ -563,6 +570,21 @@ enum Mode {
     Encode,
     Decode,
     Length
+}
+
+/// Wrap `tokens` in a `const _: () = { use #path as minicbor; ... };` block
+/// when the user has supplied `#[cbor(crate = "...")]`.
+fn wrap_in_crate_alias(path: Option<&syn::Path>, tokens: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    if let Some(p) = path {
+        quote::quote! {
+            const _: () = {
+                use #p as minicbor;
+                #tokens
+            };
+        }
+    } else {
+        tokens
+    }
 }
 
 /// Derive the `minicbor::CborLen` trait for a struct or enum.

--- a/minicbor-tests/tests/crate_attr.rs
+++ b/minicbor-tests/tests/crate_attr.rs
@@ -1,0 +1,60 @@
+//! Tests for `#[cbor(crate = "...")]`.
+//!
+//! The private module `minicbor` below shadows the real crate with a dummy
+//! type, so any generated code that reaches for the implicit `minicbor` path
+//! would fail to compile. Derives in this file therefore have to rely on the
+//! crate path supplied via `#[cbor(crate = "...")]`.
+
+mod minicbor {
+    #[allow(non_camel_case_types, dead_code)]
+    pub struct DO_NOT_USE_THIS;
+}
+
+use ::minicbor as renamed_minicbor;
+
+#[derive(renamed_minicbor::Encode, renamed_minicbor::Decode, renamed_minicbor::CborLen)]
+#[cbor(crate = "renamed_minicbor")]
+struct ReexportStruct {
+    #[n(0)] a: u32,
+    #[n(1)] b: Option<bool>,
+}
+
+#[derive(renamed_minicbor::Encode, renamed_minicbor::Decode, renamed_minicbor::CborLen)]
+#[cbor(crate = "renamed_minicbor", map)]
+enum ReexportEnum {
+    #[n(0)] Unit,
+    #[n(1)] Tuple(#[n(0)] u32),
+    #[n(2)] Struct {
+        #[n(0)] x: u32,
+        #[cbor(n(1), skip_if = "Option::is_none")] y: Option<bool>,
+    },
+}
+
+#[test]
+fn roundtrip_struct() {
+    let s = ReexportStruct { a: 7, b: Some(true) };
+    let bytes = renamed_minicbor::to_vec(&s).unwrap();
+    let back: ReexportStruct = renamed_minicbor::decode(&bytes).unwrap();
+    assert_eq!(back.a, 7);
+    assert_eq!(back.b, Some(true));
+    assert_eq!(bytes.len(), renamed_minicbor::len(&s));
+}
+
+#[test]
+fn roundtrip_enum() {
+    for variant in [
+        ReexportEnum::Unit,
+        ReexportEnum::Tuple(42),
+        ReexportEnum::Struct { x: 1, y: None },
+        ReexportEnum::Struct { x: 1, y: Some(false) },
+    ] {
+        let bytes = renamed_minicbor::to_vec(&variant).unwrap();
+        let back: ReexportEnum = renamed_minicbor::decode(&bytes).unwrap();
+        assert!(matches!(
+            (variant, back),
+            (ReexportEnum::Unit, ReexportEnum::Unit)
+                | (ReexportEnum::Tuple(_), ReexportEnum::Tuple(_))
+                | (ReexportEnum::Struct { .. }, ReexportEnum::Struct { .. })
+        ));
+    }
+}


### PR DESCRIPTION
Allows re-exporters of the derive macros to point the generated code at a different path for the `minicbor` crate, similar to serde's `#[serde(crate = "...")]`. The attribute is valid on structs and enums and threads the path through every reference (trait paths, `Encoder`/`Decoder`, errors, default codec functions, internal `__minicbor_cfg!` macro, etc).


 ```rust
  // In a crate that re-exports minicbor and its derives:
  pub use minicbor;
  pub use minicbor::{Encode, Decode, CborLen};

  // Downstream users only depend on `my_crate` — `minicbor` may not be
  // in scope, so the derive needs to be told where to find it.
  use my_crate::{Encode, Decode};

  #[derive(Encode, Decode)]
  #[cbor(crate = "my_crate::minicbor")]
  struct Point {
      #[n(0)] x: f64,
      #[n(1)] y: f64,
  }
```