### PR TITLE
Add buffer getters on io Readers and Writers

### DIFF
--- a/minicbor-io/src/async_reader.rs
+++ b/minicbor-io/src/async_reader.rs
@@ -50,6 +50,16 @@ impl<R> AsyncReader<R> {
         self.max_len = val as usize
     }
 
+    /// Get a reference to the inner buffer.
+    pub fn buffer(&self) -> &Vec<u8> {
+        &self.buffer
+    }
+
+    /// Get a mutable reference to the inner buffer.
+    pub fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buffer
+    }
+
     /// Get a reference to the inner reader.
     pub fn reader(&self) -> &R {
         &self.reader

--- a/minicbor-io/src/async_writer.rs
+++ b/minicbor-io/src/async_writer.rs
@@ -43,6 +43,16 @@ impl<W> AsyncWriter<W> {
         self.max_len = val as usize
     }
 
+    /// Get a reference to the inner buffer.
+    pub fn buffer(&self) -> &Vec<u8> {
+        &self.buffer
+    }
+
+    /// Get a mutable reference to the inner buffer.
+    pub fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buffer
+    }
+
     /// Get a reference to the inner writer.
     pub fn writer(&self) -> &W {
         &self.writer

--- a/minicbor-io/src/reader.rs
+++ b/minicbor-io/src/reader.rs
@@ -29,6 +29,16 @@ impl<R> Reader<R> {
         self.max_len = val as usize
     }
 
+    /// Get a reference to the inner buffer.
+    pub fn buffer(&self) -> &Vec<u8> {
+        &self.buffer
+    }
+
+    /// Get a mutable reference to the inner buffer.
+    pub fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buffer
+    }
+
     /// Get a reference to the inner reader.
     pub fn reader(&self) -> &R {
         &self.reader

--- a/minicbor-io/src/writer.rs
+++ b/minicbor-io/src/writer.rs
@@ -29,6 +29,16 @@ impl<W> Writer<W> {
         self.max_len = val as usize
     }
 
+    /// Get a reference to the inner buffer.
+    pub fn buffer(&self) -> &Vec<u8> {
+        &self.buffer
+    }
+
+    /// Get a mutable reference to the inner buffer.
+    pub fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buffer
+    }
+
     /// Get a reference to the inner writer.
     pub fn writer(&self) -> &W {
         &self.writer


### PR DESCRIPTION
I would like to know if the buffer is empty before I deconstruct it `into_parts()`.

```rust
reader.buffer().is_empty()
```