### PR TITLE
Add Decode for Box<[T]> and byte string impls for boxed slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 # minicbor
 
+## Unreleased
+
+- `Decode` is implemented for `Box<[T]>`, complementing the existing `Encode` and `CborLen`
+  impls of `Box<T: ?Sized>`.
+- `Encode`, `Decode` and `CborLen` are implemented for `Box<ByteSlice>`, and `EncodeBytes`,
+  `DecodeBytes` and `CborLenBytes` for `Box<[u8]>` and `Box<ByteSlice>`, so boxed slices can
+  be encoded as CBOR bytes with `#[cbor(with = "minicbor::bytes")]`.
+
 ## `2.3.0`
 
 - Adds support for `u128`/`i128`. See pull request [63][pr63] by @sdbondi for details.

--- a/minicbor-tests/src/bytes.rs
+++ b/minicbor-tests/src/bytes.rs
@@ -46,6 +46,19 @@ struct Vector {
 }
 
 #[derive(Encode, Decode)]
+struct BoxedSlice {
+    #[n(0)]
+    #[cbor(with = "minicbor::bytes")]
+    field: Box<[u8]>
+}
+
+#[derive(Encode, Decode)]
+struct BoxedByteSlice {
+    #[n(0)]
+    field: Box<ByteSlice>
+}
+
+#[derive(Encode, Decode)]
 struct CowVector<'a> {
     #[n(0)]
     field: Cow<'a, ByteVec>

--- a/minicbor-tests/tests/identities.rs
+++ b/minicbor-tests/tests/identities.rs
@@ -272,6 +272,34 @@ fn byte_vec() {
 }
 
 #[test]
+fn boxed_slice() {
+    fn property(arg: Vec<u32>) -> bool {
+        identity(arg.into_boxed_slice())
+    }
+
+    quickcheck(property as fn(Vec<u32>) -> bool)
+}
+
+#[test]
+fn boxed_byte_slice() {
+    use minicbor::bytes::ByteSlice;
+
+    fn property(arg: Vec<u8>) -> bool {
+        let arg: Box<ByteSlice> = arg.into_boxed_slice().into();
+        let vec = minicbor::to_vec(&arg).unwrap();
+        assert_eq!(minicbor::len(&arg), vec.len());
+        let mut dec = Decoder::new(&vec);
+        assert_eq!(Some(Type::Bytes), dec.datatype().ok());
+        dec.set_position(0);
+        let val: Box<ByteSlice> = dec.decode().unwrap();
+        assert_eq!(dec.position(), vec.len());
+        arg == val
+    }
+
+    quickcheck(property as fn(Vec<u8>) -> bool)
+}
+
+#[test]
 fn vecdeque() {
     quickcheck(identity as fn(std::collections::VecDeque<u32>) -> bool)
 }

--- a/minicbor/src/bytes.rs
+++ b/minicbor/src/bytes.rs
@@ -9,20 +9,20 @@
 //! If the feature "derive" is present, specialised traits `EncodeBytes` and
 //! `DecodeBytes` are also provided. These are implemented for the
 //! aforementioned newtypes as well as for their `Option` variations, regular
-//! `&[u8]`, `[u8; N]`, `Vec<u8>` and for `Cow<'_, [u8]>` if the alloc feature
-//! is given. They enable the direct use of `&[u8]`, `[u8; N]`, `Vec<u8>` and
-//! `Cow<'_, [u8]>` in types deriving `Encode` and `Decode` if used with a
-//! `#[cbor(with = "minicbor::bytes")]` annotation.
+//! `&[u8]`, `[u8; N]`, `Vec<u8>`, `Box<[u8]>` and for `Cow<'_, [u8]>` if the
+//! alloc feature is given. They enable the direct use of `&[u8]`, `[u8; N]`,
+//! `Vec<u8>`, `Box<[u8]>` and `Cow<'_, [u8]>` in types deriving `Encode` and
+//! `Decode` if used with a `#[cbor(with = "minicbor::bytes")]` annotation.
 
 use crate::decode::{self, Decode, Decoder};
 use crate::encode::{self, Encode, Encoder, Write, CborLen};
 use core::ops::{Deref, DerefMut};
 
 #[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 #[cfg(all(feature = "alloc", feature = "derive"))]
-use alloc::{boxed::Box, borrow::{Cow, ToOwned}};
+use alloc::borrow::{Cow, ToOwned};
 
 /// Newtype for `[u8]`.
 ///
@@ -44,6 +44,24 @@ impl<'a> From<&'a mut [u8]> for &'a mut ByteSlice {
     fn from(xs: &'a mut [u8]) -> Self {
         unsafe {
             &mut *(xs as *mut [u8] as *mut ByteSlice)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<Box<[u8]>> for Box<ByteSlice> {
+    fn from(xs: Box<[u8]>) -> Self {
+        unsafe {
+            Box::from_raw(Box::into_raw(xs) as *mut ByteSlice)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<Box<ByteSlice>> for Box<[u8]> {
+    fn from(xs: Box<ByteSlice>) -> Self {
+        unsafe {
+            Box::from_raw(Box::into_raw(xs) as *mut [u8])
         }
     }
 }
@@ -77,6 +95,13 @@ impl AsMut<[u8]> for ByteSlice {
 impl<'a, 'b: 'a, C> Decode<'b, C> for &'a ByteSlice {
     fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, decode::Error> {
         d.bytes().map(<&ByteSlice>::from)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<C> Decode<'_, C> for Box<ByteSlice> {
+    fn decode(d: &mut Decoder<'_>, _: &mut C) -> Result<Self, decode::Error> {
+        d.bytes().map(|b| Box::<[u8]>::from(b).into())
     }
 }
 
@@ -397,6 +422,27 @@ impl<C> CborLenBytes<C> for Box<[u8]> {
     fn cbor_len(&self, ctx: &mut C) -> usize {
         let n = self.len();
         n.cbor_len(ctx) + n
+    }
+}
+
+#[cfg(all(feature = "alloc", feature = "derive"))]
+impl<C> EncodeBytes<C> for Box<ByteSlice> {
+    fn encode_bytes<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), encode::Error<W::Error>> {
+        ByteSlice::encode(self, e, ctx)
+    }
+}
+
+#[cfg(all(feature = "alloc", feature = "derive"))]
+impl<C> DecodeBytes<'_, C> for Box<ByteSlice> {
+    fn decode_bytes(d: &mut Decoder<'_>, ctx: &mut C) -> Result<Self, decode::Error> {
+        Self::decode(d, ctx)
+    }
+}
+
+#[cfg(all(feature = "alloc", feature = "derive"))]
+impl<C> CborLenBytes<C> for Box<ByteSlice> {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        <ByteSlice as CborLen<C>>::cbor_len(self, ctx)
     }
 }
 

--- a/minicbor/src/decode.rs
+++ b/minicbor/src/decode.rs
@@ -120,6 +120,13 @@ impl<'b, C> Decode<'b, C> for alloc::boxed::Box<str> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<'b, C, T: Decode<'b, C>> Decode<'b, C> for alloc::boxed::Box<[T]> {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, Error> {
+        alloc::vec::Vec::<T>::decode(d, ctx).map(Into::into)
+    }
+}
+
 impl<'b, C, T: Decode<'b, C>> Decode<'b, C> for Option<T> {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, Error> {
         if crate::data::Type::Null == d.datatype()? {


### PR DESCRIPTION
Adds a `Decode` impl for `Box<[T]>`, which previously could not be decoded even though `Encode` and `CborLen` already covered it via the blanket `Box<T: ?Sized>` impls. Also adds the byte string equivalents so `Box<[u8]>` and `Box<ByteSlice>` work with `#[cbor(with = "minicbor::bytes")]`.